### PR TITLE
fix: add return value in exposed api

### DIFF
--- a/includes/core.h
+++ b/includes/core.h
@@ -13,12 +13,12 @@ InstrumentHooks *instrument_hooks_init(void);
 void instrument_hooks_deinit(InstrumentHooks *);
 
 bool instrument_hooks_is_instrumented(InstrumentHooks *);
-void instrument_hooks_start_benchmark(InstrumentHooks *);
-void instrument_hooks_stop_benchmark(InstrumentHooks *);
-void instrument_hooks_executed_benchmark(InstrumentHooks *, int32_t pid, const char *uri);
-void instrument_hooks_set_integration(InstrumentHooks *, const char *name, const char *version);
+int8_t instrument_hooks_start_benchmark(InstrumentHooks *);
+int8_t instrument_hooks_stop_benchmark(InstrumentHooks *);
+int8_t instrument_hooks_executed_benchmark(InstrumentHooks *, int32_t pid, const char *uri);
+int8_t instrument_hooks_set_integration(InstrumentHooks *, const char *name, const char *version);
 
-void callgrind_start_instrumentation();
-void callgrind_stop_instrumentation();
+int8_t callgrind_start_instrumentation();
+int8_t callgrind_stop_instrumentation();
 
 #endif

--- a/src/tests/main.c
+++ b/src/tests/main.c
@@ -1,18 +1,30 @@
 #include <stdio.h>
+#include <stdint.h>
 #include "../../includes/core.h"
 
 int main() {
     InstrumentHooks* instance = instrument_hooks_init();
+    if (instance == NULL) {
+        printf("Failed to initialize instrument hooks\n");
+        return -1;
+    }
+    printf("Instrument hooks initialized successfully\n");
 
     bool result = instrument_hooks_is_instrumented(instance);
     printf("Instrumented: %s\n", result ? "true" : "false");
 
-    instrument_hooks_start_benchmark(instance);
-    instrument_hooks_stop_benchmark(instance);
-    instrument_hooks_set_integration(instance, "c-test", "0.1");
-    instrument_hooks_executed_benchmark(instance, 42, "example_uri");
+    int8_t status = 0;
+    status = instrument_hooks_start_benchmark(instance);
+    printf("Benchmark started: %d\n", status);
 
-    printf("Test finished\n");
+    status = instrument_hooks_stop_benchmark(instance);
+    printf("Benchmark stopped: %d\n", status);
+
+    status = instrument_hooks_set_integration(instance, "c-test", "0.1");
+    printf("Integration set: %d\n", status);
+
+    status = instrument_hooks_executed_benchmark(instance, 42, "example_uri");
+    printf("Executed benchmark: %d\n", status);
 
     instrument_hooks_deinit(instance);
 }


### PR DESCRIPTION
Forgot to change the exposed API in the previous PR. 

```
clang -O3 src/tests/main.c dist/core.c -I includes/ -o clang-main && ./clang-main
Instrument hooks initialized successfully
Instrumented: false
Benchmark started: 0
Benchmark stopped: 0
Integration set: 0
Executed benchmark: 0
```