### PR TITLE
fix: add marker windows stubs

### DIFF
--- a/dist/core.c
+++ b/dist/core.c
@@ -42,6 +42,13 @@ uint8_t instrument_hooks_set_integration(InstrumentHooks* hooks,
 void instrument_hooks_set_feature(InstrumentHooks* hooks, uint64_t feature,
                                   bool enabled) {}
 
+uint64_t instrument_hooks_current_timestamp() { return 0; }
+
+uint8_t instrument_hooks_add_marker(InstrumentHooks* hooks, uint32_t pid,
+                                    uint8_t marker_type, uint64_t timestamp) {
+  return 0;
+}
+
 #else
 #define ZIG_TARGET_MAX_INT_ALIGNMENT 16
 #include "zig.h"

--- a/example/main.c
+++ b/example/main.c
@@ -8,6 +8,13 @@
 
 #include "core.h"
 
+static int fib(int n) {
+  if (n <= 1) return n;
+  return fib(n - 1) + fib(n - 2);
+}
+
+static void expensive_setup(void) { fib(30); }
+
 void example_function() {
   // Simulate some work
   for (volatile int i = 0; i < 100000; i++)
@@ -39,8 +46,21 @@ int main() {
     return 1;
   }
 
+  uint32_t pid = getpid();
   for (int i = 0; i < 10; i++) {
+    // This won't be displayed in the flamegraph, because it's outside
+    // the benchmark marker regions.
+    expensive_setup();
+
+    uint64_t start_time = instrument_hooks_current_timestamp();
     example_function();
+    uint64_t end_time = instrument_hooks_current_timestamp();
+
+    // Add the markers which mark when the benchmarked function was running
+    instrument_hooks_add_marker(hooks, pid, MARKER_TYPE_BENCHMARK_START,
+                                start_time);
+    instrument_hooks_add_marker(hooks, pid, MARKER_TYPE_BENCHMARK_END,
+                                end_time);
   }
 
   if (instrument_hooks_stop_benchmark_inline(hooks) != 0) {
@@ -49,7 +69,6 @@ int main() {
     return 1;
   }
 
-  int32_t pid = getpid();
   if (instrument_hooks_set_executed_benchmark(hooks, pid,
                                               "example_benchmark") != 0) {
     printf("Failed to report benchmark execution\n");

--- a/includes/core.h
+++ b/includes/core.h
@@ -26,27 +26,27 @@ InstrumentHooks *instrument_hooks_init(void);
 void instrument_hooks_deinit(InstrumentHooks *);
 
 bool instrument_hooks_is_instrumented(InstrumentHooks *);
-int8_t instrument_hooks_start_benchmark(InstrumentHooks *);
-int8_t instrument_hooks_stop_benchmark(InstrumentHooks *);
-int8_t instrument_hooks_set_executed_benchmark(InstrumentHooks *, int32_t pid,
-                                               const char *uri);
+uint8_t instrument_hooks_start_benchmark(InstrumentHooks *);
+uint8_t instrument_hooks_stop_benchmark(InstrumentHooks *);
+uint8_t instrument_hooks_set_executed_benchmark(InstrumentHooks *, int32_t pid,
+                                                const char *uri);
 // Deprecated: use instrument_hooks_set_executed_benchmark instead
-int8_t instrument_hooks_executed_benchmark(InstrumentHooks *, int32_t pid,
-                                           const char *uri);
-int8_t instrument_hooks_set_integration(InstrumentHooks *, const char *name,
-                                        const char *version);
+uint8_t instrument_hooks_executed_benchmark(InstrumentHooks *, int32_t pid,
+                                            const char *uri);
+uint8_t instrument_hooks_set_integration(InstrumentHooks *, const char *name,
+                                         const char *version);
 
 #define MARKER_TYPE_SAMPLE_START 0
 #define MARKER_TYPE_SAMPLE_END 1
 #define MARKER_TYPE_BENCHMARK_START 2
 #define MARKER_TYPE_BENCHMARK_END 3
 
-int8_t instrument_hooks_add_marker(InstrumentHooks *, uint32_t pid,
-                                   uint8_t marker_type, uint64_t timestamp);
+uint8_t instrument_hooks_add_marker(InstrumentHooks *, uint32_t pid,
+                                    uint8_t marker_type, uint64_t timestamp);
 uint64_t instrument_hooks_current_timestamp(void);
 
-int8_t callgrind_start_instrumentation();
-int8_t callgrind_stop_instrumentation();
+void callgrind_start_instrumentation();
+void callgrind_stop_instrumentation();
 
 // Feature flags for instrument hooks
 
@@ -61,7 +61,7 @@ void instrument_hooks_set_feature(instrument_hooks_feature_t feature,
 // directly consume the headers such as C or C++. This will allow for more
 // precise tracking of the benchmark performance.
 
-static inline int8_t instrument_hooks_start_benchmark_inline(
+static inline uint8_t instrument_hooks_start_benchmark_inline(
     InstrumentHooks *instance) {
   instrument_hooks_set_feature(FEATURE_DISABLE_CALLGRIND_MARKERS, true);
   if (instrument_hooks_start_benchmark(instance) != 0) {
@@ -73,7 +73,7 @@ static inline int8_t instrument_hooks_start_benchmark_inline(
   return 0;
 }
 
-static inline int8_t instrument_hooks_stop_benchmark_inline(
+static inline uint8_t instrument_hooks_stop_benchmark_inline(
     InstrumentHooks *instance) {
   CALLGRIND_STOP_INSTRUMENTATION;
   return instrument_hooks_stop_benchmark(instance);

--- a/scripts/stub.c
+++ b/scripts/stub.c
@@ -38,3 +38,10 @@ uint8_t instrument_hooks_set_integration(InstrumentHooks* hooks,
 
 void instrument_hooks_set_feature(InstrumentHooks* hooks, uint64_t feature,
                                   bool enabled) {}
+
+uint64_t instrument_hooks_current_timestamp() { return 0; }
+
+uint8_t instrument_hooks_add_marker(InstrumentHooks* hooks, uint32_t pid,
+                                    uint8_t marker_type, uint64_t timestamp) {
+  return 0;
+}


### PR DESCRIPTION
- Fixed the return types in the header (zig exports it as u8)
- Added the missing marker functions