### PR TITLE
feat: ensure fifo is nonblocking

### DIFF
--- a/dist/core.c
+++ b/dist/core.c
@@ -49,67 +49,69 @@ struct anon__lazy_57 {
  uint8_t const *ptr;
  uintptr_t len;
 };
-struct fifo_UnixPipe_Writer__600;
-typedef struct anon__lazy_72 nav__1073_39;
-struct mem_Allocator__565;
-typedef struct anon__lazy_57 nav__1073_42;
-struct mem_Allocator_VTable__568;
-struct mem_Allocator__565 {
- void *ptr;
- struct mem_Allocator_VTable__568 const *vtable;
-};
 struct fs_File__608;
+typedef struct anon__lazy_74 nav__1074_39;
+typedef struct anon__lazy_57 nav__1074_41;
 struct fs_File__608 {
  int32_t handle;
 };
-struct fifo_UnixPipe_Writer__600 {
- struct mem_Allocator__565 allocator;
- struct fs_File__608 file;
-};
-struct anon__lazy_72 {
- struct fifo_UnixPipe_Writer__600 payload;
+struct anon__lazy_74 {
+ struct fs_File__608 payload;
  uint16_t error;
 };
-struct fs_File_OpenFlags__1852;
-struct fs_File_OpenFlags__1852 {
+struct fs_File_OpenFlags__1858;
+struct fs_File_OpenFlags__1858 {
  uint8_t mode;
  uint8_t lock;
  bool lock_nonblocking;
  bool allow_ctty;
 };
-typedef struct anon__lazy_86 nav__1073_56;
-struct anon__lazy_86 {
- struct fs_File__608 payload;
+struct fifo_UnixPipe_Writer__600;
+typedef struct anon__lazy_82 nav__1076_39;
+struct mem_Allocator__565;
+typedef struct anon__lazy_57 nav__1076_42;
+struct mem_Allocator_VTable__568;
+struct mem_Allocator__565 {
+ void *ptr;
+ struct mem_Allocator_VTable__568 const *vtable;
+};
+struct fifo_UnixPipe_Writer__600 {
+ struct mem_Allocator__565 allocator;
+ struct fs_File__608 file;
+};
+struct anon__lazy_82 {
+ struct fifo_UnixPipe_Writer__600 payload;
  uint16_t error;
 };
+typedef struct anon__lazy_74 nav__1076_54;
 struct fifo_UnixPipe_Reader__602;
-typedef struct anon__lazy_89 nav__1072_39;
-typedef struct anon__lazy_57 nav__1072_42;
+typedef struct anon__lazy_93 nav__1075_39;
+typedef struct anon__lazy_57 nav__1075_42;
 struct fifo_UnixPipe_Reader__602 {
  struct mem_Allocator__565 allocator;
  struct fs_File__608 file;
 };
-struct anon__lazy_89 {
+struct anon__lazy_93 {
  struct fifo_UnixPipe_Reader__602 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_86 nav__1072_56;
+typedef struct anon__lazy_74 nav__1075_54;
 struct instruments_perf_PerfInstrument__559;
-typedef struct anon__lazy_95 nav__750_39;
+typedef struct anon__lazy_99 nav__751_39;
 struct instruments_perf_PerfInstrument__559 {
  struct mem_Allocator__565 allocator;
  struct fifo_UnixPipe_Writer__600 writer;
  struct fifo_UnixPipe_Reader__602 reader;
 };
-struct anon__lazy_95 {
+struct anon__lazy_99 {
  struct instruments_perf_PerfInstrument__559 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_57 nav__750_59;
-typedef struct anon__lazy_72 nav__750_61;
-typedef struct anon__lazy_89 nav__750_66;
+typedef struct anon__lazy_57 nav__751_59;
+typedef struct anon__lazy_82 nav__751_61;
+typedef struct anon__lazy_93 nav__751_66;
 struct instruments_root_InstrumentHooks__547;
-typedef struct anon__lazy_106 nav__725_39;
+typedef struct anon__lazy_110 nav__726_39;
 struct instruments_valgrind_ValgrindInstrument__554;
 struct instruments_valgrind_ValgrindInstrument__554 {
  struct mem_Allocator__565 allocator;
@@ -121,26 +123,26 @@ struct instruments_root_InstrumentHooks__547 {
  } payload;
  uint8_t tag;
 };
-struct anon__lazy_106 {
+struct anon__lazy_110 {
  struct instruments_root_InstrumentHooks__547 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_95 nav__725_60;
-struct shared_Command__1935;
-struct shared_Command__struct_1938__1938;
-typedef struct anon__lazy_57 nav__1077_44;
-struct shared_Command__struct_1938__1938 {
+typedef struct anon__lazy_99 nav__726_60;
+struct shared_Command__1946;
+struct shared_Command__struct_1949__1949;
+typedef struct anon__lazy_57 nav__1080_44;
+struct shared_Command__struct_1949__1949 {
  struct anon__lazy_57 uri;
  uint32_t pid;
 };
-struct shared_Command__struct_1939__1939;
-struct shared_Command__struct_1939__1939 {
+struct shared_Command__struct_1950__1950;
+struct shared_Command__struct_1950__1950 {
  struct anon__lazy_57 name;
  struct anon__lazy_57 version;
 };
-struct shared_Command__struct_1940__1940;
-struct shared_MarkerType__1942;
-struct shared_MarkerType__1942 {
+struct shared_Command__struct_1951__1951;
+struct shared_MarkerType__1953;
+struct shared_MarkerType__1953 {
  union {
   uint64_t SampleStart;
   uint64_t SampleEnd;
@@ -149,474 +151,474 @@ struct shared_MarkerType__1942 {
  } payload;
  uint8_t tag;
 };
-struct shared_Command__struct_1940__1940 {
- struct shared_MarkerType__1942 marker;
+struct shared_Command__struct_1951__1951 {
+ struct shared_MarkerType__1953 marker;
  uint32_t pid;
 };
-struct shared_Command__1935 {
+struct shared_Command__1946 {
  union {
-  struct shared_Command__struct_1938__1938 ExecutedBenchmark;
-  struct shared_Command__struct_1939__1939 SetIntegration;
-  struct shared_Command__struct_1940__1940 AddMarker;
+  struct shared_Command__struct_1949__1949 ExecutedBenchmark;
+  struct shared_Command__struct_1950__1950 SetIntegration;
+  struct shared_Command__struct_1951__1951 AddMarker;
   uint64_t SetVersion;
  } payload;
  uint8_t tag;
 };
-struct array_list_ArrayListAligned_28u8_2cnull_29__1963;
-typedef struct anon__lazy_130 nav__1077_60;
-struct anon__lazy_130 {
+struct array_list_ArrayListAligned_28u8_2cnull_29__1974;
+typedef struct anon__lazy_134 nav__1080_60;
+struct anon__lazy_134 {
  uint8_t *ptr;
  uintptr_t len;
 };
-struct array_list_ArrayListAligned_28u8_2cnull_29__1963 {
- struct anon__lazy_130 items;
+struct array_list_ArrayListAligned_28u8_2cnull_29__1974 {
+ struct anon__lazy_134 items;
  uintptr_t capacity;
  struct mem_Allocator__565 allocator;
 };
-struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994;
-struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *context;
+struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005;
+struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *context;
 };
-typedef struct anon__lazy_139 nav__4160_38;
-struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171;
-struct anon__lazy_139 {
+typedef struct anon__lazy_143 nav__4173_38;
+struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201;
+struct anon__lazy_143 {
  uint32_t payload;
  uint16_t error;
 };
-struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148;
-struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *context;
+struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178;
+struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *context;
 };
-struct io_Reader__2307;
-typedef struct anon__lazy_151 nav__4160_50;
-typedef struct anon__lazy_130 nav__4160_52;
-struct io_Reader__2307 {
+struct io_Reader__2337;
+typedef struct anon__lazy_155 nav__4173_50;
+typedef struct anon__lazy_134 nav__4173_52;
+struct io_Reader__2337 {
  void const *context;
- struct anon__lazy_151 (*readFn)(void const *, struct anon__lazy_130);
+ struct anon__lazy_155 (*readFn)(void const *, struct anon__lazy_134);
 };
-struct anon__lazy_151 {
+struct anon__lazy_155 {
  uintptr_t payload;
  uint16_t error;
 };
-typedef struct anon__lazy_161 nav__4160_64;
-struct anon__lazy_161 {
+typedef struct anon__lazy_165 nav__4173_64;
+struct anon__lazy_165 {
  uint16_t error;
  uint8_t payload[4];
 };
-typedef struct anon__lazy_139 nav__4159_38;
-typedef struct anon__lazy_130 nav__4202_39;
-typedef struct anon__lazy_165 nav__4202_40;
-struct anon__lazy_165 {
- struct anon__lazy_130 payload;
+typedef struct anon__lazy_143 nav__4172_38;
+typedef struct anon__lazy_134 nav__4215_39;
+typedef struct anon__lazy_169 nav__4215_40;
+struct anon__lazy_169 {
+ struct anon__lazy_134 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_151 nav__4202_59;
-typedef struct anon__lazy_170 nav__4202_69;
-struct anon__lazy_170 {
+typedef struct anon__lazy_155 nav__4215_59;
+typedef struct anon__lazy_174 nav__4215_69;
+struct anon__lazy_174 {
  uint64_t payload;
  uint16_t error;
 };
-typedef struct anon__lazy_173 nav__4202_72;
-struct anon__lazy_173 {
+typedef struct anon__lazy_177 nav__4215_72;
+struct anon__lazy_177 {
  uint16_t error;
  uint8_t payload[8];
 };
-typedef struct anon__lazy_57 nav__4201_39;
-typedef struct anon__lazy_176 nav__4201_40;
-struct anon__lazy_176 {
+typedef struct anon__lazy_57 nav__4214_39;
+typedef struct anon__lazy_180 nav__4214_40;
+struct anon__lazy_180 {
  struct anon__lazy_57 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_130 nav__4201_55;
-typedef struct anon__lazy_165 nav__4201_57;
-typedef struct anon__lazy_180 nav__4200_39;
-typedef struct anon__lazy_57 nav__4200_44;
-struct anon__lazy_180 {
- struct shared_Command__struct_1938__1938 payload;
+typedef struct anon__lazy_134 nav__4214_55;
+typedef struct anon__lazy_169 nav__4214_57;
+typedef struct anon__lazy_184 nav__4213_39;
+typedef struct anon__lazy_57 nav__4213_44;
+struct anon__lazy_184 {
+ struct shared_Command__struct_1949__1949 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_139 nav__4200_57;
-typedef struct anon__lazy_176 nav__4200_60;
-typedef struct anon__lazy_180 nav__4199_39;
-typedef struct anon__lazy_57 nav__4199_44;
-typedef struct anon__lazy_188 nav__4207_39;
-typedef struct anon__lazy_57 nav__4207_44;
-struct anon__lazy_188 {
- struct shared_Command__struct_1939__1939 payload;
+typedef struct anon__lazy_143 nav__4213_57;
+typedef struct anon__lazy_180 nav__4213_60;
+typedef struct anon__lazy_184 nav__4212_39;
+typedef struct anon__lazy_57 nav__4212_44;
+typedef struct anon__lazy_192 nav__4220_39;
+typedef struct anon__lazy_57 nav__4220_44;
+struct anon__lazy_192 {
+ struct shared_Command__struct_1950__1950 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_176 nav__4207_57;
-typedef struct anon__lazy_188 nav__4206_39;
-typedef struct anon__lazy_57 nav__4206_44;
-typedef struct anon__lazy_170 nav__4213_38;
-typedef struct anon__lazy_151 nav__4213_50;
-typedef struct anon__lazy_130 nav__4213_52;
-typedef struct anon__lazy_173 nav__4213_64;
-typedef struct anon__lazy_170 nav__4212_38;
-typedef struct anon__lazy_196 nav__4211_39;
-struct anon__lazy_196 {
- struct shared_MarkerType__1942 payload;
- uint16_t error;
-};
-typedef struct anon__lazy_139 nav__4211_54;
-typedef struct anon__lazy_170 nav__4211_56;
-typedef struct anon__lazy_196 nav__4210_39;
-typedef struct anon__lazy_200 nav__4209_39;
+typedef struct anon__lazy_180 nav__4220_57;
+typedef struct anon__lazy_192 nav__4219_39;
+typedef struct anon__lazy_57 nav__4219_44;
+typedef struct anon__lazy_174 nav__4226_38;
+typedef struct anon__lazy_155 nav__4226_50;
+typedef struct anon__lazy_134 nav__4226_52;
+typedef struct anon__lazy_177 nav__4226_64;
+typedef struct anon__lazy_174 nav__4225_38;
+typedef struct anon__lazy_200 nav__4224_39;
 struct anon__lazy_200 {
- struct shared_Command__struct_1940__1940 payload;
+ struct shared_MarkerType__1953 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_139 nav__4209_57;
-typedef struct anon__lazy_196 nav__4209_60;
-typedef struct anon__lazy_200 nav__4208_39;
-typedef struct anon__lazy_205 nav__4158_39;
-typedef struct anon__lazy_57 nav__4158_45;
-struct anon__lazy_205 {
- struct shared_Command__1935 payload;
+typedef struct anon__lazy_143 nav__4224_54;
+typedef struct anon__lazy_174 nav__4224_56;
+typedef struct anon__lazy_200 nav__4223_39;
+typedef struct anon__lazy_204 nav__4222_39;
+struct anon__lazy_204 {
+ struct shared_Command__struct_1951__1951 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_139 nav__4158_66;
-typedef struct anon__lazy_180 nav__4158_68;
-typedef struct anon__lazy_188 nav__4158_70;
-typedef struct anon__lazy_200 nav__4158_72;
-typedef struct anon__lazy_170 nav__4158_74;
-typedef struct anon__lazy_205 nav__4157_39;
-typedef struct anon__lazy_57 nav__4157_45;
-typedef struct anon__lazy_205 nav__1082_39;
-typedef struct anon__lazy_57 nav__1082_45;
-typedef struct anon__lazy_130 nav__1082_71;
-typedef struct anon__lazy_151 nav__1082_74;
-typedef struct anon__lazy_165 nav__1082_78;
-struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 {
- struct anon__lazy_130 buffer;
+typedef struct anon__lazy_143 nav__4222_57;
+typedef struct anon__lazy_200 nav__4222_60;
+typedef struct anon__lazy_204 nav__4221_39;
+typedef struct anon__lazy_209 nav__4171_39;
+typedef struct anon__lazy_57 nav__4171_45;
+struct anon__lazy_209 {
+ struct shared_Command__1946 payload;
+ uint16_t error;
+};
+typedef struct anon__lazy_143 nav__4171_66;
+typedef struct anon__lazy_184 nav__4171_68;
+typedef struct anon__lazy_192 nav__4171_70;
+typedef struct anon__lazy_204 nav__4171_72;
+typedef struct anon__lazy_174 nav__4171_74;
+typedef struct anon__lazy_209 nav__4170_39;
+typedef struct anon__lazy_57 nav__4170_45;
+typedef struct anon__lazy_209 nav__1085_39;
+typedef struct anon__lazy_57 nav__1085_45;
+typedef struct anon__lazy_134 nav__1085_71;
+typedef struct anon__lazy_155 nav__1085_74;
+typedef struct anon__lazy_169 nav__1085_78;
+struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 {
+ struct anon__lazy_134 buffer;
  uintptr_t pos;
 };
-typedef struct anon__lazy_205 nav__1083_39;
-typedef struct anon__lazy_214 nav__1083_42;
-typedef struct anon__lazy_57 nav__1083_46;
-struct anon__lazy_214 {
+typedef struct anon__lazy_209 nav__1086_39;
+typedef struct anon__lazy_218 nav__1086_42;
+typedef struct anon__lazy_57 nav__1086_46;
+struct anon__lazy_218 {
  uint64_t payload;
  bool is_null;
 };
-typedef struct anon__lazy_214 nav__1084_40;
-typedef struct anon__lazy_57 nav__1084_48;
-typedef struct anon__lazy_205 nav__1084_60;
-typedef struct anon__lazy_57 nav__759_58;
-typedef struct anon__lazy_214 nav__759_71;
-typedef struct anon__lazy_225 nav__238_46;
-struct anon__lazy_225 {
+typedef struct anon__lazy_218 nav__1087_40;
+typedef struct anon__lazy_57 nav__1087_48;
+typedef struct anon__lazy_209 nav__1087_60;
+typedef struct anon__lazy_57 nav__760_58;
+typedef struct anon__lazy_218 nav__760_71;
+typedef struct anon__lazy_229 nav__239_46;
+struct anon__lazy_229 {
  struct instruments_root_InstrumentHooks__547 *payload;
  uint16_t error;
 };
-typedef struct anon__lazy_130 nav__238_51;
+typedef struct anon__lazy_134 nav__239_51;
 struct mem_Allocator_VTable__568 {
  uint8_t *(*alloc)(void *, uintptr_t, uint8_t, uintptr_t);
- bool (*resize)(void *, struct anon__lazy_130, uint8_t, uintptr_t, uintptr_t);
- uint8_t *(*remap)(void *, struct anon__lazy_130, uint8_t, uintptr_t, uintptr_t);
- void (*free)(void *, struct anon__lazy_130, uint8_t, uintptr_t);
+ bool (*resize)(void *, struct anon__lazy_134, uint8_t, uintptr_t, uintptr_t);
+ uint8_t *(*remap)(void *, struct anon__lazy_134, uint8_t, uintptr_t, uintptr_t);
+ void (*free)(void *, struct anon__lazy_134, uint8_t, uintptr_t);
 };
-typedef struct anon__lazy_106 nav__238_72;
-typedef struct anon__lazy_225 nav__3574_40;
-typedef struct anon__lazy_239 nav__3574_51;
-struct anon__lazy_239 {
+typedef struct anon__lazy_110 nav__239_72;
+typedef struct anon__lazy_229 nav__3577_40;
+typedef struct anon__lazy_246 nav__3577_51;
+struct anon__lazy_246 {
  uint8_t *payload;
  uint16_t error;
 };
-typedef struct anon__lazy_57 nav__1139_39;
-struct fs_Dir__1854;
-struct fs_Dir__1854 {
+typedef struct anon__lazy_57 nav__1142_39;
+struct fs_Dir__1860;
+struct fs_Dir__1860 {
  int32_t fd;
 };
-typedef struct anon__lazy_86 nav__1136_39;
-typedef struct anon__lazy_57 nav__1136_41;
-typedef struct anon__lazy_57 nav__752_44;
-typedef struct anon__lazy_214 nav__752_72;
-typedef struct anon__lazy_57 nav__753_45;
-typedef struct anon__lazy_130 nav__3876_42;
-typedef struct anon__lazy_57 nav__4049_46;
-typedef struct anon__lazy_130 nav__3878_41;
-typedef struct anon__lazy_57 nav__1230_40;
-typedef struct anon__lazy_151 nav__1230_47;
-struct os_linux_timespec__struct_2843__2843;
-struct os_linux_timespec__struct_2843__2843 {
+typedef struct anon__lazy_74 nav__1139_39;
+typedef struct anon__lazy_57 nav__1139_41;
+typedef struct anon__lazy_57 nav__753_44;
+typedef struct anon__lazy_218 nav__753_72;
+typedef struct anon__lazy_57 nav__754_45;
+typedef struct anon__lazy_134 nav__3888_42;
+typedef struct anon__lazy_57 nav__4061_46;
+typedef struct anon__lazy_134 nav__3890_41;
+typedef struct anon__lazy_57 nav__1233_40;
+typedef struct anon__lazy_155 nav__1233_47;
+struct os_linux_timespec__struct_2922__2922;
+struct os_linux_timespec__struct_2922__2922 {
  intptr_t sec;
  intptr_t nsec;
 };
-typedef struct anon__lazy_275 nav__4063_41;
-struct anon__lazy_275 {
- struct os_linux_timespec__struct_2843__2843 payload;
+typedef struct anon__lazy_283 nav__4075_41;
+struct anon__lazy_283 {
+ struct os_linux_timespec__struct_2922__2922 payload;
  uint16_t error;
 };
-typedef struct anon__lazy_151 nav__1220_38;
-typedef struct anon__lazy_130 nav__1220_41;
-typedef struct anon__lazy_130 nav__4091_39;
-typedef struct anon__lazy_165 nav__4091_40;
-typedef struct anon__lazy_239 nav__4091_51;
-typedef struct anon__lazy_130 nav__4123_40;
-typedef struct anon__lazy_151 nav__4156_38;
-typedef struct anon__lazy_130 nav__4156_41;
-typedef struct anon__lazy_161 nav__4198_39;
-typedef struct anon__lazy_151 nav__4198_44;
-typedef struct anon__lazy_130 nav__4198_46;
-typedef struct anon__lazy_173 nav__4203_39;
-typedef struct anon__lazy_151 nav__4203_44;
-typedef struct anon__lazy_130 nav__4203_46;
-typedef struct anon__lazy_151 nav__4163_38;
-typedef struct anon__lazy_130 nav__4163_41;
-typedef struct anon__lazy_57 nav__4204_40;
-typedef struct anon__lazy_298 nav__4204_42;
-struct anon__lazy_298 {
+typedef struct anon__lazy_155 nav__1223_38;
+typedef struct anon__lazy_134 nav__1223_41;
+typedef struct anon__lazy_134 nav__4103_39;
+typedef struct anon__lazy_169 nav__4103_40;
+typedef struct anon__lazy_246 nav__4103_51;
+typedef struct anon__lazy_134 nav__4104_40;
+typedef struct anon__lazy_134 nav__4136_40;
+typedef struct anon__lazy_155 nav__4169_38;
+typedef struct anon__lazy_134 nav__4169_41;
+typedef struct anon__lazy_165 nav__4211_39;
+typedef struct anon__lazy_155 nav__4211_44;
+typedef struct anon__lazy_134 nav__4211_46;
+typedef struct anon__lazy_177 nav__4216_39;
+typedef struct anon__lazy_155 nav__4216_44;
+typedef struct anon__lazy_134 nav__4216_46;
+typedef struct anon__lazy_155 nav__4176_38;
+typedef struct anon__lazy_134 nav__4176_41;
+typedef struct anon__lazy_57 nav__4217_40;
+typedef struct anon__lazy_310 nav__4217_42;
+struct anon__lazy_310 {
  uintptr_t payload;
  bool is_null;
 };
-typedef struct anon__lazy_130 nav__4214_40;
-struct cimport_struct_timespec__3022;
-struct cimport_struct_timespec__3022 {
+struct cimport_struct_timespec__3100;
+struct cimport_struct_timespec__3100 {
  long tv_sec;
  long tv_nsec;
 };
-typedef struct anon__lazy_309 nav__4219_42;
-struct anon__lazy_309 {
+typedef struct anon__lazy_317 nav__3832_42;
+struct anon__lazy_317 {
  long payload;
  bool is_null;
 };
-typedef struct anon__lazy_57 nav__3824_43;
-typedef struct anon__lazy_239 nav__4222_39;
-typedef struct anon__lazy_130 nav__4222_52;
-typedef struct anon__lazy_57 nav__4257_39;
-typedef struct anon__lazy_57 nav__3780_40;
-typedef struct anon__lazy_325 nav__3780_49;
-struct anon__lazy_325 {
+typedef struct anon__lazy_57 nav__3836_43;
+typedef struct anon__lazy_134 nav__4228_52;
+typedef struct anon__lazy_246 nav__4229_39;
+typedef struct anon__lazy_134 nav__4229_52;
+typedef struct anon__lazy_57 nav__4264_39;
+typedef struct anon__lazy_57 nav__3783_40;
+typedef struct anon__lazy_339 nav__3783_49;
+struct anon__lazy_339 {
  uint16_t error;
  uint8_t payload[4096];
 };
-typedef struct anon__lazy_86 nav__3716_39;
-typedef struct anon__lazy_57 nav__3716_42;
-typedef struct anon__lazy_325 nav__3716_53;
-typedef struct anon__lazy_57 nav__4320_46;
-typedef struct anon__lazy_130 nav__3924_39;
-typedef struct anon__lazy_151 nav__1229_38;
-typedef struct anon__lazy_57 nav__1229_41;
-typedef struct anon__lazy_275 nav__1630_39;
-typedef struct anon__lazy_151 nav__1219_38;
-typedef struct anon__lazy_130 nav__1219_41;
-typedef struct anon__lazy_239 nav__4321_39;
-typedef struct anon__lazy_151 nav__4321_49;
-typedef struct anon__lazy_151 nav__4115_38;
-typedef struct anon__lazy_130 nav__4115_42;
-typedef struct anon__lazy_130 nav__4165_40;
-typedef struct anon__lazy_151 nav__4165_43;
-typedef struct anon__lazy_151 nav__4164_38;
-typedef struct anon__lazy_130 nav__4164_41;
-typedef struct anon__lazy_57 nav__4323_39;
-typedef struct anon__lazy_298 nav__4323_40;
-typedef struct anon__lazy_130 nav__4350_39;
-typedef struct anon__lazy_309 nav__5194_38;
-typedef struct anon__lazy_57 nav__5963_40;
-typedef struct anon__lazy_130 nav__5963_51;
-typedef struct anon__lazy_57 nav__4263_39;
-typedef struct anon__lazy_325 nav__1714_39;
-typedef struct anon__lazy_57 nav__1714_41;
-typedef struct anon__lazy_130 nav__1714_47;
-typedef struct anon__lazy_86 nav__3717_39;
-typedef struct anon__lazy_358 nav__3717_50;
-struct anon__lazy_358 {
+typedef struct anon__lazy_74 nav__3719_39;
+typedef struct anon__lazy_57 nav__3719_42;
+typedef struct anon__lazy_339 nav__3719_53;
+typedef struct anon__lazy_57 nav__5247_46;
+typedef struct anon__lazy_134 nav__3936_39;
+typedef struct anon__lazy_155 nav__1232_38;
+typedef struct anon__lazy_57 nav__1232_41;
+typedef struct anon__lazy_283 nav__1633_39;
+typedef struct anon__lazy_155 nav__1222_38;
+typedef struct anon__lazy_134 nav__1222_41;
+typedef struct anon__lazy_246 nav__5248_39;
+typedef struct anon__lazy_155 nav__5248_49;
+typedef struct anon__lazy_134 nav__5249_39;
+typedef struct anon__lazy_155 nav__4128_38;
+typedef struct anon__lazy_134 nav__4128_42;
+typedef struct anon__lazy_134 nav__4178_40;
+typedef struct anon__lazy_155 nav__4178_43;
+typedef struct anon__lazy_155 nav__4177_38;
+typedef struct anon__lazy_134 nav__4177_41;
+typedef struct anon__lazy_57 nav__5251_39;
+typedef struct anon__lazy_310 nav__5251_40;
+typedef struct anon__lazy_317 nav__6121_38;
+typedef struct anon__lazy_57 nav__6890_40;
+typedef struct anon__lazy_134 nav__6890_51;
+typedef struct anon__lazy_57 nav__4270_39;
+typedef struct anon__lazy_339 nav__1717_39;
+typedef struct anon__lazy_57 nav__1717_41;
+typedef struct anon__lazy_134 nav__1717_47;
+typedef struct anon__lazy_74 nav__3720_39;
+typedef struct anon__lazy_374 nav__3720_50;
+struct anon__lazy_374 {
  int32_t payload;
  uint16_t error;
 };
-typedef struct anon__lazy_57 nav__5977_45;
-typedef struct anon__lazy_57 nav__5979_45;
-typedef struct anon__lazy_151 nav__1449_38;
-typedef struct anon__lazy_57 nav__1449_40;
-typedef struct anon__lazy_151 nav__1441_38;
-typedef struct anon__lazy_130 nav__1441_40;
-typedef struct anon__lazy_151 nav__6049_38;
-typedef struct anon__lazy_382 nav__6049_42;
-struct anon__lazy_382 {
+typedef struct anon__lazy_57 nav__6905_45;
+typedef struct anon__lazy_57 nav__6907_45;
+typedef struct anon__lazy_155 nav__1452_38;
+typedef struct anon__lazy_57 nav__1452_40;
+typedef struct anon__lazy_155 nav__1444_38;
+typedef struct anon__lazy_134 nav__1444_40;
+typedef struct anon__lazy_155 nav__6977_38;
+typedef struct anon__lazy_398 nav__6977_42;
+struct anon__lazy_398 {
  uintptr_t f0;
  uint8_t f1;
 };
-typedef struct anon__lazy_239 nav__6050_39;
-typedef struct anon__lazy_130 nav__6050_52;
-typedef struct anon__lazy_151 nav__4162_38;
-typedef struct anon__lazy_130 nav__4162_41;
-typedef struct anon__lazy_57 nav__6052_39;
-typedef struct anon__lazy_358 nav__1461_38;
-struct io_Writer__3831;
-typedef struct anon__lazy_151 nav__6113_48;
-typedef struct anon__lazy_57 nav__6113_50;
-struct io_Writer__3831 {
+typedef struct anon__lazy_246 nav__6978_39;
+typedef struct anon__lazy_134 nav__6978_52;
+typedef struct anon__lazy_155 nav__4175_38;
+typedef struct anon__lazy_134 nav__4175_41;
+typedef struct anon__lazy_57 nav__6980_39;
+typedef struct anon__lazy_374 nav__1464_38;
+struct io_Writer__3920;
+typedef struct anon__lazy_155 nav__7041_48;
+typedef struct anon__lazy_57 nav__7041_50;
+struct io_Writer__3920 {
  void const *context;
- struct anon__lazy_151 (*writeFn)(void const *, struct anon__lazy_57);
+ struct anon__lazy_155 (*writeFn)(void const *, struct anon__lazy_57);
 };
-typedef struct anon__lazy_57 nav__6114_45;
-typedef struct anon__lazy_57 nav__6115_45;
-typedef struct anon__lazy_151 nav__6117_48;
-typedef struct anon__lazy_57 nav__6117_50;
-typedef struct anon__lazy_151 nav__4048_38;
-typedef struct anon__lazy_57 nav__4048_41;
-typedef struct anon__lazy_57 nav__6132_40;
-typedef struct anon__lazy_151 nav__6132_43;
-typedef struct anon__lazy_57 nav__6141_40;
-typedef struct anon__lazy_151 nav__3902_38;
-typedef struct anon__lazy_57 nav__3902_42;
-typedef struct anon__lazy_151 nav__6131_38;
-typedef struct anon__lazy_57 nav__6131_41;
-typedef struct anon__lazy_57 nav__6143_40;
-typedef struct anon__lazy_151 nav__6143_51;
-typedef struct anon__lazy_57 nav__3896_41;
-typedef struct anon__lazy_130 nav__3915_43;
-typedef struct anon__lazy_151 nav__3915_52;
-typedef struct anon__lazy_57 nav__3897_41;
-typedef struct anon__lazy_130 nav__3897_47;
-typedef struct anon__lazy_151 nav__3840_38;
-typedef struct anon__lazy_382 nav__3840_42;
-typedef struct anon__lazy_130 nav__3913_43;
-typedef struct anon__lazy_130 nav__3914_43;
-typedef struct anon__lazy_165 nav__3914_55;
-typedef struct anon__lazy_130 nav__6230_39;
-typedef struct anon__lazy_151 nav__6230_50;
-typedef struct anon__lazy_130 nav__6231_39;
-typedef struct anon__lazy_165 nav__6231_40;
-typedef struct anon__lazy_239 nav__6231_51;
-typedef struct anon__lazy_130 nav__6232_39;
-typedef struct anon__lazy_130 nav__239_63;
-typedef struct anon__lazy_130 nav__6233_52;
-typedef struct anon__lazy_57 nav__754_58;
-typedef struct anon__lazy_214 nav__754_71;
+typedef struct anon__lazy_57 nav__7042_45;
+typedef struct anon__lazy_57 nav__7043_45;
+typedef struct anon__lazy_155 nav__7045_48;
+typedef struct anon__lazy_57 nav__7045_50;
+typedef struct anon__lazy_155 nav__4060_38;
+typedef struct anon__lazy_57 nav__4060_41;
+typedef struct anon__lazy_57 nav__7060_40;
+typedef struct anon__lazy_155 nav__7060_43;
+typedef struct anon__lazy_57 nav__7069_40;
+typedef struct anon__lazy_155 nav__3914_38;
+typedef struct anon__lazy_57 nav__3914_42;
+typedef struct anon__lazy_155 nav__7059_38;
+typedef struct anon__lazy_57 nav__7059_41;
+typedef struct anon__lazy_57 nav__7071_40;
+typedef struct anon__lazy_155 nav__7071_51;
+typedef struct anon__lazy_57 nav__3908_41;
+typedef struct anon__lazy_134 nav__3927_43;
+typedef struct anon__lazy_155 nav__3927_52;
+typedef struct anon__lazy_57 nav__3909_41;
+typedef struct anon__lazy_134 nav__3909_47;
+typedef struct anon__lazy_155 nav__3852_38;
+typedef struct anon__lazy_398 nav__3852_42;
+typedef struct anon__lazy_134 nav__3925_43;
+typedef struct anon__lazy_134 nav__3926_43;
+typedef struct anon__lazy_169 nav__3926_55;
+typedef struct anon__lazy_134 nav__7158_39;
+typedef struct anon__lazy_155 nav__7158_50;
+typedef struct anon__lazy_134 nav__7159_39;
+typedef struct anon__lazy_169 nav__7159_40;
+typedef struct anon__lazy_246 nav__7159_51;
+typedef struct anon__lazy_134 nav__7160_39;
+typedef struct anon__lazy_134 nav__240_63;
 typedef struct anon__lazy_57 nav__755_58;
-typedef struct anon__lazy_214 nav__755_71;
-typedef struct anon__lazy_57 nav__756_56;
-typedef struct anon__lazy_214 nav__756_71;
-typedef struct anon__lazy_57 nav__6238_39;
-typedef struct anon__lazy_451 nav__6240_45;
-struct anon__lazy_451 {
+typedef struct anon__lazy_218 nav__755_71;
+typedef struct anon__lazy_57 nav__756_58;
+typedef struct anon__lazy_218 nav__756_71;
+typedef struct anon__lazy_57 nav__757_56;
+typedef struct anon__lazy_218 nav__757_71;
+typedef struct anon__lazy_57 nav__7165_39;
+typedef struct anon__lazy_459 nav__7167_45;
+struct anon__lazy_459 {
  bool array[32];
 };
-typedef struct anon__lazy_453 nav__6240_47;
-struct anon__lazy_453 {
+typedef struct anon__lazy_461 nav__7167_47;
+struct anon__lazy_461 {
  bool is_null;
  uint8_t payload;
 };
-typedef struct anon__lazy_453 nav__6606_38;
-typedef struct anon__lazy_451 nav__6606_40;
-typedef struct anon__lazy_57 nav__757_56;
-typedef struct anon__lazy_214 nav__757_71;
-typedef struct anon__lazy_466 nav__245_62;
-struct anon__lazy_466 {
+typedef struct anon__lazy_461 nav__7533_38;
+typedef struct anon__lazy_459 nav__7533_40;
+typedef struct anon__lazy_57 nav__758_56;
+typedef struct anon__lazy_218 nav__758_71;
+typedef struct anon__lazy_474 nav__246_62;
+struct anon__lazy_474 {
  uint8_t const *f0;
  uint8_t const *f1;
 };
-typedef struct anon__lazy_130 nav__245_65;
-typedef struct anon__lazy_165 nav__245_67;
-typedef struct anon__lazy_130 nav__6614_39;
-typedef struct anon__lazy_165 nav__6614_40;
-typedef struct anon__lazy_466 nav__6614_43;
-typedef struct anon__lazy_130 nav__6615_40;
-typedef struct anon__lazy_130 nav__6616_39;
-typedef struct anon__lazy_165 nav__6616_40;
-typedef struct anon__lazy_466 nav__6616_43;
-typedef struct anon__lazy_298 nav__6616_54;
-typedef struct anon__lazy_130 nav__6617_39;
-typedef struct anon__lazy_466 nav__6659_40;
-typedef struct anon__lazy_151 nav__6659_43;
-typedef struct anon__lazy_57 nav__6659_44;
-struct fmt_FormatOptions__4866;
-typedef struct anon__lazy_298 nav__6659_55;
-struct fmt_FormatOptions__4866 {
- struct anon__lazy_298 precision;
- struct anon__lazy_298 width;
+typedef struct anon__lazy_134 nav__246_65;
+typedef struct anon__lazy_169 nav__246_67;
+typedef struct anon__lazy_134 nav__7541_39;
+typedef struct anon__lazy_169 nav__7541_40;
+typedef struct anon__lazy_474 nav__7541_43;
+typedef struct anon__lazy_134 nav__7542_40;
+typedef struct anon__lazy_134 nav__7543_39;
+typedef struct anon__lazy_169 nav__7543_40;
+typedef struct anon__lazy_474 nav__7543_43;
+typedef struct anon__lazy_310 nav__7543_54;
+typedef struct anon__lazy_134 nav__7544_39;
+typedef struct anon__lazy_474 nav__7586_40;
+typedef struct anon__lazy_155 nav__7586_43;
+typedef struct anon__lazy_57 nav__7586_44;
+struct fmt_FormatOptions__4926;
+typedef struct anon__lazy_310 nav__7586_55;
+struct fmt_FormatOptions__4926 {
+ struct anon__lazy_310 precision;
+ struct anon__lazy_310 width;
  uint32_t fill;
  uint8_t alignment;
 };
-typedef struct anon__lazy_466 nav__6618_39;
-struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516;
-struct io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29__4508;
-struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 {
+typedef struct anon__lazy_474 nav__7545_39;
+struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576;
+struct io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29__4568;
+struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 {
  uint64_t bytes_written;
 };
-struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536;
-struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 {
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *context;
+struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596;
+struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 {
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *context;
 };
-typedef struct anon__lazy_151 nav__6618_53;
-typedef struct anon__lazy_57 nav__6618_54;
-typedef struct anon__lazy_298 nav__6619_38;
-typedef struct anon__lazy_130 nav__6620_39;
-typedef struct anon__lazy_165 nav__6620_40;
-typedef struct anon__lazy_466 nav__6620_42;
-struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924;
-struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *context;
+typedef struct anon__lazy_155 nav__7545_53;
+typedef struct anon__lazy_57 nav__7545_54;
+typedef struct anon__lazy_310 nav__7546_38;
+typedef struct anon__lazy_134 nav__7547_39;
+typedef struct anon__lazy_169 nav__7547_40;
+typedef struct anon__lazy_474 nav__7547_42;
+struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984;
+struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *context;
 };
-typedef struct anon__lazy_151 nav__6620_57;
-typedef struct anon__lazy_57 nav__6620_58;
-typedef struct anon__lazy_151 nav__6658_38;
-typedef struct anon__lazy_57 nav__6658_41;
-typedef struct anon__lazy_298 nav__6827_42;
-typedef struct anon__lazy_151 nav__6827_46;
-typedef struct anon__lazy_57 nav__6827_47;
-typedef struct anon__lazy_151 nav__6840_38;
-typedef struct anon__lazy_57 nav__6840_41;
-typedef struct anon__lazy_130 nav__4121_39;
-typedef struct anon__lazy_151 nav__6643_38;
-typedef struct anon__lazy_57 nav__6643_42;
-typedef struct anon__lazy_509 nav__6671_38;
-struct anon__lazy_509 {
+typedef struct anon__lazy_155 nav__7547_57;
+typedef struct anon__lazy_57 nav__7547_58;
+typedef struct anon__lazy_155 nav__7585_38;
+typedef struct anon__lazy_57 nav__7585_41;
+typedef struct anon__lazy_310 nav__7754_42;
+typedef struct anon__lazy_155 nav__7754_46;
+typedef struct anon__lazy_57 nav__7754_47;
+typedef struct anon__lazy_155 nav__7767_38;
+typedef struct anon__lazy_57 nav__7767_41;
+typedef struct anon__lazy_134 nav__4134_39;
+typedef struct anon__lazy_155 nav__7570_38;
+typedef struct anon__lazy_57 nav__7570_42;
+typedef struct anon__lazy_517 nav__7598_38;
+struct anon__lazy_517 {
  uint16_t error;
  uint8_t payload;
 };
-typedef struct anon__lazy_151 nav__6687_38;
-typedef struct anon__lazy_57 nav__6687_40;
-typedef struct anon__lazy_509 nav__6687_48;
-typedef struct anon__lazy_139 nav__6687_50;
-typedef struct anon__lazy_57 nav__6841_39;
-typedef struct anon__lazy_298 nav__6841_44;
-typedef struct anon__lazy_151 nav__6841_48;
-typedef struct anon__lazy_130 nav__6841_57;
-typedef struct anon__lazy_509 nav__6841_60;
-typedef struct anon__lazy_151 nav__4116_38;
-typedef struct anon__lazy_57 nav__4116_42;
-typedef struct anon__lazy_130 nav__4116_50;
-typedef struct anon__lazy_151 nav__4026_38;
-typedef struct anon__lazy_57 nav__4026_40;
-typedef struct anon__lazy_139 nav__6677_38;
-typedef struct anon__lazy_57 nav__6677_40;
-typedef struct anon__lazy_524 nav__6677_48;
-struct anon__lazy_524 {
+typedef struct anon__lazy_155 nav__7614_38;
+typedef struct anon__lazy_57 nav__7614_40;
+typedef struct anon__lazy_517 nav__7614_48;
+typedef struct anon__lazy_143 nav__7614_50;
+typedef struct anon__lazy_57 nav__7768_39;
+typedef struct anon__lazy_310 nav__7768_44;
+typedef struct anon__lazy_155 nav__7768_48;
+typedef struct anon__lazy_134 nav__7768_57;
+typedef struct anon__lazy_517 nav__7768_60;
+typedef struct anon__lazy_155 nav__4129_38;
+typedef struct anon__lazy_57 nav__4129_42;
+typedef struct anon__lazy_134 nav__4129_50;
+typedef struct anon__lazy_155 nav__4038_38;
+typedef struct anon__lazy_57 nav__4038_40;
+typedef struct anon__lazy_143 nav__7604_38;
+typedef struct anon__lazy_57 nav__7604_40;
+typedef struct anon__lazy_532 nav__7604_48;
+struct anon__lazy_532 {
  uint8_t array[2];
 };
-typedef struct anon__lazy_526 nav__6677_52;
-struct anon__lazy_526 {
+typedef struct anon__lazy_534 nav__7604_52;
+struct anon__lazy_534 {
  uint8_t array[3];
 };
-typedef struct anon__lazy_528 nav__6677_56;
-struct anon__lazy_528 {
+typedef struct anon__lazy_536 nav__7604_56;
+struct anon__lazy_536 {
  uint8_t array[4];
 };
-typedef struct anon__lazy_509 nav__6670_38;
-typedef struct anon__lazy_509 nav__6842_38;
-typedef struct anon__lazy_130 nav__6842_40;
-typedef struct anon__lazy_509 nav__6672_38;
-typedef struct anon__lazy_130 nav__6672_40;
-typedef struct anon__lazy_57 nav__6136_40;
-typedef struct anon__lazy_151 nav__6136_43;
-typedef struct anon__lazy_139 nav__6679_38;
-typedef struct anon__lazy_524 nav__6679_40;
-typedef struct anon__lazy_139 nav__6681_38;
-typedef struct anon__lazy_526 nav__6681_40;
-typedef struct anon__lazy_139 nav__6685_38;
-typedef struct anon__lazy_528 nav__6685_40;
-typedef struct anon__lazy_139 nav__6683_38;
-typedef struct anon__lazy_526 nav__6683_40;
-typedef struct anon__lazy_57 nav__758_64;
-typedef struct anon__lazy_214 nav__758_72;
-typedef struct anon__lazy_275 nav__4220_41;
+typedef struct anon__lazy_517 nav__7597_38;
+typedef struct anon__lazy_517 nav__7769_38;
+typedef struct anon__lazy_134 nav__7769_40;
+typedef struct anon__lazy_517 nav__7599_38;
+typedef struct anon__lazy_134 nav__7599_40;
+typedef struct anon__lazy_57 nav__7064_40;
+typedef struct anon__lazy_155 nav__7064_43;
+typedef struct anon__lazy_143 nav__7606_38;
+typedef struct anon__lazy_532 nav__7606_40;
+typedef struct anon__lazy_143 nav__7608_38;
+typedef struct anon__lazy_534 nav__7608_40;
+typedef struct anon__lazy_143 nav__7612_38;
+typedef struct anon__lazy_536 nav__7612_40;
+typedef struct anon__lazy_143 nav__7610_38;
+typedef struct anon__lazy_534 nav__7610_40;
+typedef struct anon__lazy_57 nav__759_64;
+typedef struct anon__lazy_218 nav__759_72;
+typedef struct anon__lazy_283 nav__3834_41;
 struct Target_Os__625;
 union Target_Os_VersionRange__681;
 struct SemanticVersion_Range__686;
 struct SemanticVersion__684;
-typedef struct anon__lazy_57 nav__264_43;
+typedef struct anon__lazy_57 nav__265_43;
 struct SemanticVersion__684 {
  uintptr_t major;
  uintptr_t minor;
@@ -659,11 +661,11 @@ struct Target_DynamicLinker__800 {
  uint8_t buffer[255];
  uint8_t len;
 };
-typedef struct anon__lazy_130 nav__3571_40;
-typedef struct anon__lazy_130 nav__3572_40;
-typedef struct anon__lazy_130 nav__3573_40;
-typedef struct anon__lazy_130 nav__3535_46;
-typedef struct anon__lazy_130 nav__235_46;
+typedef struct anon__lazy_134 nav__3574_40;
+typedef struct anon__lazy_134 nav__3575_40;
+typedef struct anon__lazy_134 nav__3576_40;
+typedef struct anon__lazy_134 nav__3538_46;
+typedef struct anon__lazy_134 nav__236_46;
 struct Target_Cpu_Feature_Set__817;
 struct Target_Cpu_Feature_Set__817 {
  uintptr_t ints[5];
@@ -675,14 +677,14 @@ struct Target_Cpu__785 {
  struct Target_Cpu_Feature_Set__817 features;
  uint8_t arch;
 };
-typedef struct anon__lazy_57 nav__263_46;
+typedef struct anon__lazy_57 nav__264_46;
 struct Target_Cpu_Model__812 {
  struct anon__lazy_57 name;
  struct anon__lazy_57 llvm_name;
  struct Target_Cpu_Feature_Set__817 features;
 };
 struct Target__623;
-typedef struct anon__lazy_57 nav__265_51;
+typedef struct anon__lazy_57 nav__266_51;
 struct Target__623 {
  struct Target_Cpu__785 cpu;
  struct Target_Os__625 os;
@@ -692,28 +694,28 @@ struct Target__623 {
 };
 struct builtin_CallingConvention__266;
 struct builtin_CallingConvention_CommonOptions__268;
-typedef struct anon__lazy_214 nav__464_40;
+typedef struct anon__lazy_218 nav__465_40;
 struct builtin_CallingConvention_CommonOptions__268 {
- struct anon__lazy_214 incoming_stack_alignment;
+ struct anon__lazy_218 incoming_stack_alignment;
 };
 struct builtin_CallingConvention_X86RegparmOptions__270;
 struct builtin_CallingConvention_X86RegparmOptions__270 {
- struct anon__lazy_214 incoming_stack_alignment;
+ struct anon__lazy_218 incoming_stack_alignment;
  uint8_t register_params;
 };
 struct builtin_CallingConvention_ArmInterruptOptions__272;
 struct builtin_CallingConvention_ArmInterruptOptions__272 {
- struct anon__lazy_214 incoming_stack_alignment;
+ struct anon__lazy_218 incoming_stack_alignment;
  uint8_t type;
 };
 struct builtin_CallingConvention_MipsInterruptOptions__274;
 struct builtin_CallingConvention_MipsInterruptOptions__274 {
- struct anon__lazy_214 incoming_stack_alignment;
+ struct anon__lazy_218 incoming_stack_alignment;
  uint8_t mode;
 };
 struct builtin_CallingConvention_RiscvInterruptOptions__276;
 struct builtin_CallingConvention_RiscvInterruptOptions__276 {
- struct anon__lazy_214 incoming_stack_alignment;
+ struct anon__lazy_218 incoming_stack_alignment;
  uint8_t mode;
 };
 struct builtin_CallingConvention__266 {
@@ -790,11 +792,11 @@ struct builtin_CallingConvention__266 {
  } payload;
  uint8_t tag;
 };
-struct std_Options__4209;
-typedef struct anon__lazy_298 nav__97_39;
-struct std_Options__4209 {
- struct anon__lazy_298 page_size_min;
- struct anon__lazy_298 page_size_max;
+struct std_Options__4269;
+typedef struct anon__lazy_310 nav__97_39;
+struct std_Options__4269 {
+ struct anon__lazy_310 page_size_min;
+ struct anon__lazy_310 page_size_max;
  uintptr_t fmt_max_depth;
  bool enable_segfault_handler;
  uint8_t log_level;
@@ -805,302 +807,313 @@ struct std_Options__4209 {
  bool http_enable_ssl_key_log_file;
  uint8_t side_channels_mitigations;
 };
-typedef struct anon__lazy_298 nav__3551_38;
-typedef struct anon__lazy_130 nav__3562_43;
-typedef struct anon__lazy_57 nav__3594_40;
+typedef struct anon__lazy_310 nav__3554_38;
+typedef struct anon__lazy_134 nav__3565_43;
+typedef struct anon__lazy_57 nav__3597_40;
 static uint8_t const __anon_1845[21];
-static uint8_t const __anon_1905[21];
-static uint8_t const __anon_2896[89];
-static uint8_t const __anon_4607[10];
-static uint8_t const __anon_4888[1];
-static uint8_t const __anon_4908[1];
-static uint8_t const __anon_5079[3];
-static uint8_t const __anon_4953[4];
-static uint8_t const __anon_5232[10];
-#define c_instrument_hooks_set_feature__237 instrument_hooks_set_feature
+static uint8_t const __anon_1916[21];
+static uint8_t const __anon_2757[70];
+static uint8_t const __anon_2761[83];
+static uint8_t const __anon_3003[89];
+static uint8_t const __anon_4667[10];
+static uint8_t const __anon_4948[1];
+static uint8_t const __anon_4968[1];
+static uint8_t const __anon_5138[3];
+static uint8_t const __anon_5013[4];
+static uint8_t const __anon_5291[10];
+#define c_instrument_hooks_set_feature__238 instrument_hooks_set_feature
 zig_extern void instrument_hooks_set_feature(uint64_t, bool);
-static void features_set_feature__324(uint64_t, bool);
-static void bit_set_IntegerBitSet_2864_29_set__363(uint64_t *, uintptr_t);
-static void bit_set_IntegerBitSet_2864_29_unset__365(uint64_t *, uintptr_t);
+static void features_set_feature__325(uint64_t, bool);
+static void bit_set_IntegerBitSet_2864_29_set__364(uint64_t *, uintptr_t);
+static void bit_set_IntegerBitSet_2864_29_unset__366(uint64_t *, uintptr_t);
 static void debug_assert__180(bool);
-static uint64_t bit_set_IntegerBitSet_2864_29_maskBit__384(uintptr_t);
-static nav__1073_39 fifo_UnixPipe_openWrite__1073(struct mem_Allocator__565, nav__1073_42);
-static nav__1072_39 fifo_UnixPipe_openRead__1072(struct mem_Allocator__565, nav__1072_42);
-static nav__750_39 instruments_perf_PerfInstrument_init__750(struct mem_Allocator__565);
-static nav__725_39 instruments_root_InstrumentHooks_init__725(struct mem_Allocator__565);
-static uint16_t fifo_UnixPipe_Writer_sendCmd__1077(struct fifo_UnixPipe_Writer__600 *, struct shared_Command__1935);
-static nav__4160_38 bincode_deserializeInt__anon_2292__4160(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171);
-static nav__4159_38 bincode_deserializeAlloc__anon_2281__4159(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4202_40 bincode_deserializePointerAlloc__anon_2418__4202(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4201_40 bincode_deserializeAlloc__anon_2405__4201(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4200_39 bincode_deserializeStructAlloc__anon_2380__4200(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4199_39 bincode_deserializeAlloc__anon_2351__4199(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static uint16_t bincode_deserializeAlloc__anon_2470__4205(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4207_39 bincode_deserializeStructAlloc__anon_2534__4207(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4206_39 bincode_deserializeAlloc__anon_2515__4206(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4213_38 bincode_deserializeInt__anon_2657__4213(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171);
-static nav__4212_38 bincode_deserializeAlloc__anon_2652__4212(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4210_39 bincode_deserializeAlloc__anon_2605__4210(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4209_39 bincode_deserializeStructAlloc__anon_2587__4209(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4208_39 bincode_deserializeAlloc__anon_2573__4208(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__4157_39 bincode_deserializeAlloc__anon_2179__4157(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171, struct mem_Allocator__565);
-static nav__1082_39 fifo_UnixPipe_Reader_recvCmd__1082(struct fifo_UnixPipe_Reader__602 *);
-static nav__1083_39 fifo_UnixPipe_Reader_waitForResponse__1083(struct fifo_UnixPipe_Reader__602 *, nav__1083_42);
-static uint16_t fifo_UnixPipe_Reader_waitForAck__1084(struct fifo_UnixPipe_Reader__602 *, nav__1084_40);
-static uint16_t instruments_perf_PerfInstrument_send_version__759(struct instruments_perf_PerfInstrument__559 *, uint64_t);
-#define c_instrument_hooks_init__238 instrument_hooks_init
+static uint64_t bit_set_IntegerBitSet_2864_29_maskBit__385(uintptr_t);
+static nav__1074_39 fifo_UnixPipe_openPipe__1074(nav__1074_41);
+static nav__1076_39 fifo_UnixPipe_openWrite__1076(struct mem_Allocator__565, nav__1076_42);
+static nav__1075_39 fifo_UnixPipe_openRead__1075(struct mem_Allocator__565, nav__1075_42);
+static nav__751_39 instruments_perf_PerfInstrument_init__751(struct mem_Allocator__565);
+static nav__726_39 instruments_root_InstrumentHooks_init__726(struct mem_Allocator__565);
+static uint16_t fifo_UnixPipe_Writer_sendCmd__1080(struct fifo_UnixPipe_Writer__600 *, struct shared_Command__1946);
+static nav__4173_38 bincode_deserializeInt__anon_2322__4173(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201);
+static nav__4172_38 bincode_deserializeAlloc__anon_2311__4172(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4215_40 bincode_deserializePointerAlloc__anon_2448__4215(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4214_40 bincode_deserializeAlloc__anon_2435__4214(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4213_39 bincode_deserializeStructAlloc__anon_2410__4213(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4212_39 bincode_deserializeAlloc__anon_2381__4212(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static uint16_t bincode_deserializeAlloc__anon_2500__4218(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4220_39 bincode_deserializeStructAlloc__anon_2564__4220(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4219_39 bincode_deserializeAlloc__anon_2545__4219(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4226_38 bincode_deserializeInt__anon_2687__4226(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201);
+static nav__4225_38 bincode_deserializeAlloc__anon_2682__4225(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4224_39 bincode_deserializeUnionAlloc__anon_2669__4224(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4223_39 bincode_deserializeAlloc__anon_2635__4223(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4222_39 bincode_deserializeStructAlloc__anon_2617__4222(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4221_39 bincode_deserializeAlloc__anon_2603__4221(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4171_39 bincode_deserializeUnionAlloc__anon_2306__4171(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__4170_39 bincode_deserializeAlloc__anon_2209__4170(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201, struct mem_Allocator__565);
+static nav__1085_39 fifo_UnixPipe_Reader_recvCmd__1085(struct fifo_UnixPipe_Reader__602 *);
+static nav__1086_39 fifo_UnixPipe_Reader_waitForResponse__1086(struct fifo_UnixPipe_Reader__602 *, nav__1086_42);
+static uint16_t fifo_UnixPipe_Reader_waitForAck__1087(struct fifo_UnixPipe_Reader__602 *, nav__1087_40);
+static uint16_t instruments_perf_PerfInstrument_send_version__760(struct instruments_perf_PerfInstrument__559 *, uint64_t);
+#define c_instrument_hooks_init__239 instrument_hooks_init
 zig_extern struct instruments_root_InstrumentHooks__547 *instrument_hooks_init(void);
-static nav__3574_40 mem_Allocator_create__anon_858__3574(struct mem_Allocator__565);
-static struct instruments_valgrind_ValgrindInstrument__554 instruments_valgrind_ValgrindInstrument_init__738(struct mem_Allocator__565);
-static uint16_t fs_accessAbsolute__1139(nav__1139_39, struct fs_File_OpenFlags__1852);
-static nav__1136_39 fs_openFileAbsolute__1136(nav__1136_41, struct fs_File_OpenFlags__1852);
-static struct fifo_UnixPipe_Writer__600 fifo_UnixPipe_Writer_init__1074(struct fs_File__608, struct mem_Allocator__565);
-static struct fifo_UnixPipe_Reader__602 fifo_UnixPipe_Reader_init__1079(struct fs_File__608, struct mem_Allocator__565);
-static uint16_t instruments_perf_PerfInstrument_send_cmd__752(struct instruments_perf_PerfInstrument__559 *, struct shared_Command__1935);
-static bool instruments_perf_PerfInstrument_is_instrumented__753(struct instruments_perf_PerfInstrument__559 *);
-static struct array_list_ArrayListAligned_28u8_2cnull_29__1963 array_list_ArrayListAligned_28u8_2cnull_29_init__3876(struct mem_Allocator__565);
-static struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 array_list_ArrayListAligned_28u8_2cnull_29_writer__3901(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *);
-static uint16_t bincode_serialize__anon_2004__4049(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__1935);
-static void array_list_ArrayListAligned_28u8_2cnull_29_deinit__3878(struct array_list_ArrayListAligned_28u8_2cnull_29__1963);
-static uint8_t const (*mem_asBytes__anon_2046__4050(uint32_t const *))[4];
-static uint16_t fs_File_writeAll__1230(struct fs_File__608, nav__1230_40);
-static zig_i128 time_nanoTimestamp__4063(void);
-static nav__1220_38 fs_File_readAll__1220(struct fs_File__608, nav__1220_41);
-static nav__4091_40 mem_Allocator_alloc__anon_2129__4091(struct mem_Allocator__565, uintptr_t);
-static struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 io_fixed_buffer_stream_fixedBufferStream__anon_2151__4123(nav__4123_40);
-static struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_reader__4112(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *);
-static nav__4156_38 io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4156(void const *, nav__4156_41);
-static nav__4198_39 io_Reader_readBytesNoEof__anon_2338__4198(struct io_Reader__2307);
-static nav__4203_39 io_Reader_readBytesNoEof__anon_2431__4203(struct io_Reader__2307);
-static nav__4163_38 io_Reader_readAll__4163(struct io_Reader__2307, nav__4163_41);
-static zig_cold zig_noreturn void bincode_invalidProtocol__anon_2455__4204(void);
-static void mem_Allocator_free__anon_2698__4214(struct mem_Allocator__565, nav__4214_40);
-static void utils_sleep__4219(uint64_t);
-static void shared_Command_deinit__3824(struct shared_Command__1935, struct mem_Allocator__565);
-static nav__4222_39 mem_Allocator_allocBytesWithAlignment__anon_2736__4222(struct mem_Allocator__565, uintptr_t, uintptr_t);
-static bool fs_path_isAbsolute__4257(nav__4257_39);
-static struct fs_Dir__1854 fs_cwd__1131(void);
-static uint16_t fs_Dir_access__3780(struct fs_Dir__1854, nav__3780_40, struct fs_File_OpenFlags__1852);
-static nav__3716_39 fs_Dir_openFile__3716(struct fs_Dir__1854, nav__3716_42, struct fs_File_OpenFlags__1852);
-static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__1935);
-static nav__3924_39 array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3924(struct array_list_ArrayListAligned_28u8_2cnull_29__1963);
-static nav__1229_38 fs_File_write__1229(struct fs_File__608, nav__1229_41);
-static nav__1630_39 posix_clock_gettime__1630(uint32_t);
-static nav__1219_38 fs_File_read__1219(struct fs_File__608, nav__1219_41);
-static nav__4321_39 mem_Allocator_allocWithSizeAndAlignment__anon_2874__4321(struct mem_Allocator__565, uintptr_t, uintptr_t);
-static nav__4115_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read__4115(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *, nav__4115_42);
-static uint16_t io_Reader_readNoEof__4165(struct io_Reader__2307, nav__4165_40);
-static nav__4164_38 io_Reader_readAtLeast__4164(struct io_Reader__2307, nav__4164_41, uintptr_t);
-static zig_cold zig_noreturn void debug_no_panic_call__4323(nav__4323_39, nav__4323_40);
-static nav__4350_39 mem_sliceAsBytes__anon_2993__4350(nav__4350_39);
-static uint8_t mem_Alignment_fromByteUnits__1045(uintptr_t);
-static nav__5194_38 math_cast__anon_3035__5194(uint64_t);
-static void mem_Allocator_free__anon_3110__5963(struct mem_Allocator__565, nav__5963_40);
-static bool fs_path_isAbsolutePosix__4263(nav__4263_39);
-static nav__1714_39 posix_toPosixPath__1714(nav__1714_41);
-static uint16_t fs_Dir_accessZ__3781(struct fs_Dir__1854, uint8_t const *, struct fs_File_OpenFlags__1852);
-static nav__3717_39 fs_Dir_openFileZ__3717(struct fs_Dir__1854, uint8_t const *, struct fs_File_OpenFlags__1852);
-static uint16_t bincode_serialize__anon_3184__5976(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, uint32_t);
-static uint16_t bincode_serialize__anon_3186__5977(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__struct_1938__1938);
-static uint16_t bincode_serialize__anon_3188__5978(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994);
-static uint16_t bincode_serialize__anon_3190__5979(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__struct_1939__1939);
-static uint16_t bincode_serialize__anon_3192__5980(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__struct_1940__1940);
-static uint16_t bincode_serialize__anon_3194__5981(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, uint64_t);
-static nav__1449_38 posix_write__1449(int32_t, nav__1449_40);
-static uint16_t posix_errno__anon_3360__6048(int);
-static uint16_t posix_unexpectedErrno__1713(uint16_t);
-static nav__1441_38 posix_read__1441(int32_t, nav__1441_40);
-static nav__6049_38 math_mul__anon_3381__6049(uintptr_t, uintptr_t);
-static nav__6050_39 mem_Allocator_allocBytesWithAlignment__anon_3383__6050(struct mem_Allocator__565, uintptr_t, uintptr_t);
-static nav__4162_38 io_Reader_read__4162(struct io_Reader__2307, nav__4162_41);
-static bool math_isPowerOfTwo__anon_3401__6051(uintptr_t);
-static nav__6052_39 mem_sliceAsBytes__anon_3417__6052(nav__6052_39);
-static uint16_t posix_faccessatZ__1605(int32_t, uint8_t const *, uint32_t, uint32_t);
-static nav__1461_38 posix_openatZ__1461(int32_t, uint8_t const *, uint32_t, uintptr_t);
-static uint16_t posix_flock__1622(int32_t, int32_t);
-static void posix_close__1419(int32_t);
-static uint16_t bincode_serializeInt__anon_3553__6113(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, uint32_t);
-static uint16_t bincode_serializeStruct__anon_3558__6114(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__struct_1938__1938);
-static uint16_t bincode_serializeStruct__anon_3559__6115(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__struct_1939__1939);
-static uint16_t bincode_serializeStruct__anon_3560__6116(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_Command__struct_1940__1940);
-static uint16_t bincode_serializeInt__anon_3561__6117(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, uint64_t);
-static uint16_t posix_errno__anon_3572__6119(intptr_t);
-static nav__4048_38 io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4048(void const *, nav__4048_41);
-static uint16_t io_Writer_writeAll__6132(struct io_Writer__3831, nav__6132_40);
-static uint16_t bincode_serialize__anon_3867__6141(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, nav__6141_40);
-static uint16_t bincode_serialize__anon_3869__6142(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_MarkerType__1942);
-static nav__3902_38 array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3902(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *, nav__3902_42);
-static nav__6131_38 io_Writer_write__6131(struct io_Writer__3831, nav__6131_41);
-static uint16_t bincode_serializePointer__anon_3882__6143(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, nav__6143_40);
-static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994, struct shared_MarkerType__1942);
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_appendSlice__3896(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *, nav__3896_41);
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureUnusedCapacity__3915(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *, uintptr_t);
-static void array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity__3897(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *, nav__3897_41);
-static nav__3840_38 array_list_addOrOom__3840(uintptr_t, uintptr_t);
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__3913(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *, uintptr_t);
-static uintptr_t array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacity__6203(uintptr_t, uintptr_t);
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPrecise__3914(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *, uintptr_t);
-static nav__6230_39 mem_Allocator_remap__anon_3940__6230(struct mem_Allocator__565, nav__6230_39, uintptr_t);
-static nav__6231_40 mem_Allocator_alignedAlloc__anon_3945__6231(struct mem_Allocator__565, uintptr_t);
-static nav__6232_39 mem_bytesAsSlice__anon_3960__6232(nav__6232_39);
-#define c_instrument_hooks_deinit__239 instrument_hooks_deinit
+static nav__3577_40 mem_Allocator_create__anon_858__3577(struct mem_Allocator__565);
+static struct instruments_valgrind_ValgrindInstrument__554 instruments_valgrind_ValgrindInstrument_init__739(struct mem_Allocator__565);
+static uint16_t fs_accessAbsolute__1142(nav__1142_39, struct fs_File_OpenFlags__1858);
+static nav__1139_39 fs_openFileAbsolute__1139(nav__1139_41, struct fs_File_OpenFlags__1858);
+static void utils_setNonBlocking__3833(int32_t);
+static struct fifo_UnixPipe_Writer__600 fifo_UnixPipe_Writer_init__1077(struct fs_File__608, struct mem_Allocator__565);
+static struct fifo_UnixPipe_Reader__602 fifo_UnixPipe_Reader_init__1082(struct fs_File__608, struct mem_Allocator__565);
+static uint16_t instruments_perf_PerfInstrument_send_cmd__753(struct instruments_perf_PerfInstrument__559 *, struct shared_Command__1946);
+static bool instruments_perf_PerfInstrument_is_instrumented__754(struct instruments_perf_PerfInstrument__559 *);
+static struct array_list_ArrayListAligned_28u8_2cnull_29__1974 array_list_ArrayListAligned_28u8_2cnull_29_init__3888(struct mem_Allocator__565);
+static struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 array_list_ArrayListAligned_28u8_2cnull_29_writer__3913(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *);
+static uint16_t bincode_serialize__anon_2015__4061(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__1946);
+static void array_list_ArrayListAligned_28u8_2cnull_29_deinit__3890(struct array_list_ArrayListAligned_28u8_2cnull_29__1974);
+static uint8_t const (*mem_asBytes__anon_2057__4062(uint32_t const *))[4];
+static uint16_t fs_File_writeAll__1233(struct fs_File__608, nav__1233_40);
+static zig_i128 time_nanoTimestamp__4075(void);
+static nav__1223_38 fs_File_readAll__1223(struct fs_File__608, nav__1223_41);
+static nav__4103_40 mem_Allocator_alloc__anon_2153__4103(struct mem_Allocator__565, uintptr_t);
+static void mem_Allocator_free__anon_2159__4104(struct mem_Allocator__565, nav__4104_40);
+static struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 io_fixed_buffer_stream_fixedBufferStream__anon_2181__4136(nav__4136_40);
+static struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_reader__4125(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *);
+static nav__4169_38 io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4169(void const *, nav__4169_41);
+static nav__4211_39 io_Reader_readBytesNoEof__anon_2368__4211(struct io_Reader__2337);
+static nav__4216_39 io_Reader_readBytesNoEof__anon_2461__4216(struct io_Reader__2337);
+static nav__4176_38 io_Reader_readAll__4176(struct io_Reader__2337, nav__4176_41);
+static zig_cold zig_noreturn void bincode_invalidProtocol__anon_2485__4217(void);
+static void utils_sleep__3832(uint64_t);
+static void shared_Command_deinit__3836(struct shared_Command__1946, struct mem_Allocator__565);
+static void instruments_perf_PerfInstrument_deinit__752(struct instruments_perf_PerfInstrument__559 *);
+static void mem_Allocator_destroy__anon_2777__4228(struct mem_Allocator__565, struct instruments_root_InstrumentHooks__547 *);
+static zig_noreturn void posix_exit__1442(uint8_t);
+static nav__4229_39 mem_Allocator_allocBytesWithAlignment__anon_2793__4229(struct mem_Allocator__565, uintptr_t, uintptr_t);
+static bool fs_path_isAbsolute__4264(nav__4264_39);
+static struct fs_Dir__1860 fs_cwd__1134(void);
+static uint16_t fs_Dir_access__3783(struct fs_Dir__1860, nav__3783_40, struct fs_File_OpenFlags__1858);
+static nav__3719_39 fs_Dir_openFile__3719(struct fs_Dir__1860, nav__3719_42, struct fs_File_OpenFlags__1858);
+static uint16_t bincode_serializeUnion__anon_2860__5247(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__1946);
+static nav__3936_39 array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3936(struct array_list_ArrayListAligned_28u8_2cnull_29__1974);
+static nav__1232_38 fs_File_write__1232(struct fs_File__608, nav__1232_41);
+static nav__1633_39 posix_clock_gettime__1633(uint32_t);
+static nav__1222_38 fs_File_read__1222(struct fs_File__608, nav__1222_41);
+static nav__5248_39 mem_Allocator_allocWithSizeAndAlignment__anon_2953__5248(struct mem_Allocator__565, uintptr_t, uintptr_t);
+static nav__5249_39 mem_sliceAsBytes__anon_2966__5249(nav__5249_39);
+static uint8_t mem_Alignment_fromByteUnits__1046(uintptr_t);
+static nav__4128_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read__4128(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *, nav__4128_42);
+static uint16_t io_Reader_readNoEof__4178(struct io_Reader__2337, nav__4178_40);
+static nav__4177_38 io_Reader_readAtLeast__4177(struct io_Reader__2337, nav__4177_41, uintptr_t);
+static zig_cold zig_noreturn void debug_no_panic_call__5251(nav__5251_39, nav__5251_40);
+static nav__6121_38 math_cast__anon_3113__6121(uint64_t);
+static void mem_Allocator_free__anon_3185__6890(struct mem_Allocator__565, nav__6890_40);
+static void fifo_UnixPipe_Writer_deinit__1081(struct fifo_UnixPipe_Writer__600 *);
+static void fifo_UnixPipe_Reader_deinit__1088(struct fifo_UnixPipe_Reader__602 *);
+static bool fs_path_isAbsolutePosix__4270(nav__4270_39);
+static nav__1717_39 posix_toPosixPath__1717(nav__1717_41);
+static uint16_t fs_Dir_accessZ__3784(struct fs_Dir__1860, uint8_t const *, struct fs_File_OpenFlags__1858);
+static nav__3720_39 fs_Dir_openFileZ__3720(struct fs_Dir__1860, uint8_t const *, struct fs_File_OpenFlags__1858);
+static uint16_t bincode_serialize__anon_3275__6904(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, uint32_t);
+static uint16_t bincode_serialize__anon_3277__6905(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__struct_1949__1949);
+static uint16_t bincode_serialize__anon_3279__6906(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005);
+static uint16_t bincode_serialize__anon_3281__6907(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__struct_1950__1950);
+static uint16_t bincode_serialize__anon_3283__6908(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__struct_1951__1951);
+static uint16_t bincode_serialize__anon_3285__6909(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, uint64_t);
+static nav__1452_38 posix_write__1452(int32_t, nav__1452_40);
+static uint16_t posix_errno__anon_3451__6976(int);
+static uint16_t posix_unexpectedErrno__1716(uint16_t);
+static nav__1444_38 posix_read__1444(int32_t, nav__1444_40);
+static nav__6977_38 math_mul__anon_3472__6977(uintptr_t, uintptr_t);
+static nav__6978_39 mem_Allocator_allocBytesWithAlignment__anon_3474__6978(struct mem_Allocator__565, uintptr_t, uintptr_t);
+static bool math_isPowerOfTwo__anon_3486__6979(uintptr_t);
+static nav__4175_38 io_Reader_read__4175(struct io_Reader__2337, nav__4175_41);
+static nav__6980_39 mem_sliceAsBytes__anon_3508__6980(nav__6980_39);
+static void fs_File_close__1179(struct fs_File__608);
+static uint16_t posix_faccessatZ__1608(int32_t, uint8_t const *, uint32_t, uint32_t);
+static nav__1464_38 posix_openatZ__1464(int32_t, uint8_t const *, uint32_t, uintptr_t);
+static uint16_t posix_flock__1625(int32_t, int32_t);
+static void posix_close__1422(int32_t);
+static uint16_t bincode_serializeInt__anon_3646__7041(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, uint32_t);
+static uint16_t bincode_serializeStruct__anon_3651__7042(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__struct_1949__1949);
+static uint16_t bincode_serializeStruct__anon_3652__7043(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__struct_1950__1950);
+static uint16_t bincode_serializeStruct__anon_3653__7044(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_Command__struct_1951__1951);
+static uint16_t bincode_serializeInt__anon_3654__7045(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, uint64_t);
+static uint16_t posix_errno__anon_3665__7047(intptr_t);
+static nav__4060_38 io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4060(void const *, nav__4060_41);
+static uint16_t io_Writer_writeAll__7060(struct io_Writer__3920, nav__7060_40);
+static uint16_t bincode_serialize__anon_3956__7069(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, nav__7069_40);
+static uint16_t bincode_serialize__anon_3958__7070(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_MarkerType__1953);
+static nav__3914_38 array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3914(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *, nav__3914_42);
+static nav__7059_38 io_Writer_write__7059(struct io_Writer__3920, nav__7059_41);
+static uint16_t bincode_serializePointer__anon_3971__7071(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, nav__7071_40);
+static uint16_t bincode_serializeUnion__anon_3972__7072(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005, struct shared_MarkerType__1953);
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_appendSlice__3908(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *, nav__3908_41);
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureUnusedCapacity__3927(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *, uintptr_t);
+static void array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity__3909(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *, nav__3909_41);
+static nav__3852_38 array_list_addOrOom__3852(uintptr_t, uintptr_t);
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__3925(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *, uintptr_t);
+static uintptr_t array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacity__7131(uintptr_t, uintptr_t);
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPrecise__3926(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *, uintptr_t);
+static nav__7158_39 mem_Allocator_remap__anon_4029__7158(struct mem_Allocator__565, nav__7158_39, uintptr_t);
+static nav__7159_40 mem_Allocator_alignedAlloc__anon_4034__7159(struct mem_Allocator__565, uintptr_t);
+static nav__7160_39 mem_bytesAsSlice__anon_4049__7160(nav__7160_39);
+#define c_instrument_hooks_deinit__240 instrument_hooks_deinit
 zig_extern void instrument_hooks_deinit(struct instruments_root_InstrumentHooks__547 *);
-static void instruments_perf_PerfInstrument_deinit__751(struct instruments_perf_PerfInstrument__559 *);
-static void mem_Allocator_destroy__anon_3975__6233(struct mem_Allocator__565, struct instruments_root_InstrumentHooks__547 *);
-static void fifo_UnixPipe_Writer_deinit__1078(struct fifo_UnixPipe_Writer__600 *);
-static void fifo_UnixPipe_Reader_deinit__1085(struct fifo_UnixPipe_Reader__602 *);
-static void fs_File_close__1176(struct fs_File__608);
-#define c_instrument_hooks_is_instrumented__240 instrument_hooks_is_instrumented
+#define c_instrument_hooks_is_instrumented__241 instrument_hooks_is_instrumented
 zig_extern bool instrument_hooks_is_instrumented(struct instruments_root_InstrumentHooks__547 *);
-static zig_cold uint16_t instruments_perf_PerfInstrument_start_benchmark__754(struct instruments_perf_PerfInstrument__559 *);
-#define c_instrument_hooks_start_benchmark__241 instrument_hooks_start_benchmark
+static zig_cold uint16_t instruments_perf_PerfInstrument_start_benchmark__755(struct instruments_perf_PerfInstrument__559 *);
+#define c_instrument_hooks_start_benchmark__242 instrument_hooks_start_benchmark
 zig_extern uint8_t instrument_hooks_start_benchmark(struct instruments_root_InstrumentHooks__547 *);
-static bool features_is_feature_enabled__325(uint64_t);
-static bool bit_set_IntegerBitSet_2864_29_isSet__360(uint64_t, uintptr_t);
-static zig_cold uint16_t instruments_perf_PerfInstrument_stop_benchmark__755(struct instruments_perf_PerfInstrument__559 *);
-#define c_instrument_hooks_stop_benchmark__242 instrument_hooks_stop_benchmark
+static bool features_is_feature_enabled__326(uint64_t);
+static bool bit_set_IntegerBitSet_2864_29_isSet__361(uint64_t, uintptr_t);
+static zig_cold uint16_t instruments_perf_PerfInstrument_stop_benchmark__756(struct instruments_perf_PerfInstrument__559 *);
+#define c_instrument_hooks_stop_benchmark__243 instrument_hooks_stop_benchmark
 zig_extern uint8_t instrument_hooks_stop_benchmark(struct instruments_root_InstrumentHooks__547 *);
-static uint16_t instruments_perf_PerfInstrument_set_executed_benchmark__756(struct instruments_perf_PerfInstrument__559 *, uint32_t, uint8_t const *);
-#define c_instrument_hooks_set_executed_benchmark__243 instrument_hooks_set_executed_benchmark
+static uint16_t instruments_perf_PerfInstrument_set_executed_benchmark__757(struct instruments_perf_PerfInstrument__559 *, uint32_t, uint8_t const *);
+#define c_instrument_hooks_set_executed_benchmark__244 instrument_hooks_set_executed_benchmark
 zig_extern uint8_t instrument_hooks_set_executed_benchmark(struct instruments_root_InstrumentHooks__547 *, uint32_t, uint8_t const *);
-static nav__6238_39 mem_span__anon_4096__6238(uint8_t const *);
-static uintptr_t mem_len__anon_4105__6239(uint8_t const *);
-static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *);
-static bool math_isPowerOfTwo__anon_4124__6241(void);
-static nav__6606_38 simd_firstTrue__anon_4336__6606(nav__6606_40);
-static uintptr_t mem_alignForward__anon_4339__6607(uintptr_t, uintptr_t);
-static bool mem_isAligned__914(uintptr_t, uintptr_t);
-static bool mem_isValidAlignGeneric__anon_4397__6608(uintptr_t);
-static uintptr_t mem_alignBackward__anon_4398__6609(uintptr_t, uintptr_t);
-static bool mem_isAlignedGeneric__anon_4404__6610(uint64_t, uint64_t);
-static uint64_t mem_alignBackward__anon_4406__6611(uint64_t, uint64_t);
-static bool mem_isValidAlignGeneric__anon_4408__6612(uint64_t);
-static bool math_isPowerOfTwo__anon_4409__6613(uint64_t);
-#define c_instrument_hooks_executed_benchmark__244 instrument_hooks_executed_benchmark
+static nav__7165_39 mem_span__anon_4156__7165(uint8_t const *);
+static uintptr_t mem_len__anon_4165__7166(uint8_t const *);
+static uintptr_t mem_indexOfSentinel__anon_4173__7167(uint8_t const *);
+static bool math_isPowerOfTwo__anon_4184__7168(void);
+static nav__7533_38 simd_firstTrue__anon_4396__7533(nav__7533_40);
+static uintptr_t mem_alignForward__anon_4399__7534(uintptr_t, uintptr_t);
+static bool mem_isAligned__915(uintptr_t, uintptr_t);
+static bool mem_isValidAlignGeneric__anon_4457__7535(uintptr_t);
+static uintptr_t mem_alignBackward__anon_4458__7536(uintptr_t, uintptr_t);
+static bool mem_isAlignedGeneric__anon_4464__7537(uint64_t, uint64_t);
+static uint64_t mem_alignBackward__anon_4466__7538(uint64_t, uint64_t);
+static bool mem_isValidAlignGeneric__anon_4468__7539(uint64_t);
+static bool math_isPowerOfTwo__anon_4469__7540(uint64_t);
+#define c_instrument_hooks_executed_benchmark__245 instrument_hooks_executed_benchmark
 zig_extern uint8_t instrument_hooks_executed_benchmark(struct instruments_root_InstrumentHooks__547 *, uint32_t, uint8_t const *);
-static uint16_t instruments_perf_PerfInstrument_set_integration__757(struct instruments_perf_PerfInstrument__559 *, uint8_t const *, uint8_t const *);
-#define c_instrument_hooks_set_integration__245 instrument_hooks_set_integration
+static uint16_t instruments_perf_PerfInstrument_set_integration__758(struct instruments_perf_PerfInstrument__559 *, uint8_t const *, uint8_t const *);
+#define c_instrument_hooks_set_integration__246 instrument_hooks_set_integration
 zig_extern uint8_t instrument_hooks_set_integration(struct instruments_root_InstrumentHooks__547 *, uint8_t const *, uint8_t const *);
-static nav__6614_40 fmt_allocPrintZ__anon_4446__6614(struct mem_Allocator__565, nav__6614_43);
-static void mem_Allocator_free__anon_4448__6615(struct mem_Allocator__565, nav__6615_40);
-static nav__6616_40 fmt_allocPrint__anon_4473__6616(struct mem_Allocator__565, nav__6616_43);
-static nav__6617_39 mem_sliceAsBytes__anon_4480__6617(nav__6617_39);
-static uint16_t fmt_format__anon_4555__6659(struct io_Writer__3831, nav__6659_40);
-static uint64_t fmt_count__anon_4487__6618(nav__6618_39);
-static nav__6619_38 math_cast__anon_4489__6619(uint64_t);
-static nav__6620_40 fmt_bufPrint__anon_4498__6620(nav__6620_39, nav__6620_42);
-static struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 io_counting_writer_countingWriter__anon_4519__6645(void);
-static struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_writer__6644(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *);
-static nav__6658_38 io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWr__6658(void const *, nav__6658_41);
-static uint16_t fmt_formatType__anon_4880__6827(uint8_t const *, struct fmt_FormatOptions__4866, struct io_Writer__3831, uintptr_t);
-static struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_writer__4113(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *);
-static nav__6840_38 io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write__6840(void const *, nav__6840_41);
-static nav__4121_39 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWritten__4121(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148);
-static nav__6643_38 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_write__6643(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *, nav__6643_42);
-static nav__6671_38 unicode_utf8ByteSequenceLength__6671(uint8_t);
-static nav__6687_38 unicode_utf8CountCodepoints__6687(nav__6687_40);
-static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39, struct fmt_FormatOptions__4866, struct io_Writer__3831);
-static nav__4116_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write__4116(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *, nav__4116_42);
-static nav__4026_38 io_dummyWrite__4026(nav__4026_40);
-static nav__6677_38 unicode_utf8Decode__6677(nav__6677_40);
-static nav__6670_38 unicode_utf8CodepointSequenceLength__6670(uint32_t);
-static nav__6842_38 unicode_utf8EncodeImpl__anon_5111__6842(uint32_t, nav__6842_40);
-static nav__6672_38 unicode_utf8Encode__6672(uint32_t, nav__6672_40);
-static uint16_t io_Writer_writeBytesNTimes__6136(struct io_Writer__3831, nav__6136_40, uintptr_t);
-static nav__6679_38 unicode_utf8Decode2__6679(nav__6679_40);
-static nav__6681_38 unicode_utf8Decode3__6681(nav__6681_40);
-static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40);
-static bool unicode_isSurrogateCodepoint__6750(uint32_t);
-static nav__6683_38 unicode_utf8Decode3AllowSurrogateHalf__6683(nav__6683_40);
-static uint16_t instruments_perf_PerfInstrument_add_marker__758(struct instruments_perf_PerfInstrument__559 *, uint32_t, struct shared_MarkerType__1942);
-#define c_instrument_hooks_add_marker__250 instrument_hooks_add_marker
+static nav__7541_40 fmt_allocPrintZ__anon_4506__7541(struct mem_Allocator__565, nav__7541_43);
+static void mem_Allocator_free__anon_4508__7542(struct mem_Allocator__565, nav__7542_40);
+static nav__7543_40 fmt_allocPrint__anon_4533__7543(struct mem_Allocator__565, nav__7543_43);
+static nav__7544_39 mem_sliceAsBytes__anon_4540__7544(nav__7544_39);
+static uint16_t fmt_format__anon_4615__7586(struct io_Writer__3920, nav__7586_40);
+static uint64_t fmt_count__anon_4547__7545(nav__7545_39);
+static nav__7546_38 math_cast__anon_4549__7546(uint64_t);
+static nav__7547_40 fmt_bufPrint__anon_4558__7547(nav__7547_39, nav__7547_42);
+static struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 io_counting_writer_countingWriter__anon_4579__7572(void);
+static struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_writer__7571(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *);
+static nav__7585_38 io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWr__7585(void const *, nav__7585_41);
+static uint16_t fmt_formatType__anon_4940__7754(uint8_t const *, struct fmt_FormatOptions__4926, struct io_Writer__3920, uintptr_t);
+static struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_writer__4126(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *);
+static nav__7767_38 io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write__7767(void const *, nav__7767_41);
+static nav__4134_39 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWritten__4134(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178);
+static nav__7570_38 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_write__7570(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *, nav__7570_42);
+static nav__7598_38 unicode_utf8ByteSequenceLength__7598(uint8_t);
+static nav__7614_38 unicode_utf8CountCodepoints__7614(nav__7614_40);
+static uint16_t fmt_formatBuf__anon_5040__7768(nav__7768_39, struct fmt_FormatOptions__4926, struct io_Writer__3920);
+static nav__4129_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write__4129(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *, nav__4129_42);
+static nav__4038_38 io_dummyWrite__4038(nav__4038_40);
+static nav__7604_38 unicode_utf8Decode__7604(nav__7604_40);
+static nav__7597_38 unicode_utf8CodepointSequenceLength__7597(uint32_t);
+static nav__7769_38 unicode_utf8EncodeImpl__anon_5170__7769(uint32_t, nav__7769_40);
+static nav__7599_38 unicode_utf8Encode__7599(uint32_t, nav__7599_40);
+static uint16_t io_Writer_writeBytesNTimes__7064(struct io_Writer__3920, nav__7064_40, uintptr_t);
+static nav__7606_38 unicode_utf8Decode2__7606(nav__7606_40);
+static nav__7608_38 unicode_utf8Decode3__7608(nav__7608_40);
+static nav__7612_38 unicode_utf8Decode4__7612(nav__7612_40);
+static bool unicode_isSurrogateCodepoint__7677(uint32_t);
+static nav__7610_38 unicode_utf8Decode3AllowSurrogateHalf__7610(nav__7610_40);
+static uint16_t instruments_perf_PerfInstrument_add_marker__759(struct instruments_perf_PerfInstrument__559 *, uint32_t, struct shared_MarkerType__1953);
+#define c_instrument_hooks_add_marker__251 instrument_hooks_add_marker
 zig_extern uint8_t instrument_hooks_add_marker(struct instruments_root_InstrumentHooks__547 *, uint32_t, uint8_t, uint64_t);
-#define c_instrument_hooks_current_timestamp__251 instrument_hooks_current_timestamp
+#define c_instrument_hooks_current_timestamp__252 instrument_hooks_current_timestamp
 zig_extern uint64_t instrument_hooks_current_timestamp(void);
-static uint64_t utils_clock_gettime_monotonic__4220(void);
-static uint64_t const builtin_zig_backend__256;
+static uint64_t utils_clock_gettime_monotonic__3834(void);
+static uint64_t const builtin_zig_backend__257;
 static bool const start_simplified_logic__109;
-static uint8_t const builtin_output_mode__257;
-static uint8_t const builtin_link_mode__258;
-static uint64_t features_features__323;
-static uintptr_t const bit_set_IntegerBitSet_2864_29_bit_length__354;
-static bool const builtin_link_libc__268;
-static bool const posix_use_libc__1282;
-static struct Target_Os__625 const builtin_os__264;
-static uint8_t const c_native_os__1724;
-static struct Target_DynamicLinker__800 const Target_DynamicLinker_none__3446;
-static bool const builtin_is_test__260;
-static uint8_t *heap_CAllocator_alloc__3570(void *, uintptr_t, uint8_t, uintptr_t);
-static bool heap_CAllocator_resize__3571(void *, nav__3571_40, uint8_t, uintptr_t, uintptr_t);
-static uint8_t *heap_CAllocator_remap__3572(void *, nav__3572_40, uint8_t, uintptr_t, uintptr_t);
-static void heap_CAllocator_free__3573(void *, nav__3573_40, uint8_t, uintptr_t);
-static uint8_t *heap_CAllocator_alignedAlloc__3567(uintptr_t, uint8_t);
-static uintptr_t heap_CAllocator_alignedAllocSize__3569(uint8_t *);
-static void heap_CAllocator_alignedFree__3568(uint8_t *);
-static uintptr_t mem_Alignment_toByteUnits__1044(uint8_t);
-static struct mem_Allocator__565 const heap_c_allocator__3535;
-static struct mem_Allocator__565 const c_allocator__235;
-static struct Target_Cpu_Feature_Set__817 const Target_Cpu_Feature_Set_empty__3491;
-static struct Target_Cpu__785 const builtin_cpu__263;
-static uint8_t const builtin_abi__262;
-static uint8_t const builtin_object_format__266;
-static struct Target__623 const builtin_target__265;
-static struct builtin_CallingConvention__266 const builtin_CallingConvention_c__464;
+static uint8_t const builtin_output_mode__258;
+static uint8_t const builtin_link_mode__259;
+static uint64_t features_features__324;
+static uintptr_t const bit_set_IntegerBitSet_2864_29_bit_length__355;
+static bool const builtin_link_libc__269;
+static bool const posix_use_libc__1285;
+static struct Target_Os__625 const builtin_os__265;
+static uint8_t const c_native_os__1727;
+static struct Target_DynamicLinker__800 const Target_DynamicLinker_none__3449;
+static bool const builtin_is_test__261;
+static uint8_t *heap_CAllocator_alloc__3573(void *, uintptr_t, uint8_t, uintptr_t);
+static bool heap_CAllocator_resize__3574(void *, nav__3574_40, uint8_t, uintptr_t, uintptr_t);
+static uint8_t *heap_CAllocator_remap__3575(void *, nav__3575_40, uint8_t, uintptr_t, uintptr_t);
+static void heap_CAllocator_free__3576(void *, nav__3576_40, uint8_t, uintptr_t);
+static uint8_t *heap_CAllocator_alignedAlloc__3570(uintptr_t, uint8_t);
+static uintptr_t heap_CAllocator_alignedAllocSize__3572(uint8_t *);
+static void heap_CAllocator_alignedFree__3571(uint8_t *);
+static uintptr_t mem_Alignment_toByteUnits__1045(uint8_t);
+static struct mem_Allocator__565 const heap_c_allocator__3538;
+static struct mem_Allocator__565 const c_allocator__236;
+static struct Target_Cpu_Feature_Set__817 const Target_Cpu_Feature_Set_empty__3494;
+static struct Target_Cpu__785 const builtin_cpu__264;
+static uint8_t const builtin_abi__263;
+static uint8_t const builtin_object_format__267;
+static struct Target__623 const builtin_target__266;
+static struct builtin_CallingConvention__266 const builtin_CallingConvention_c__465;
 zig_extern uint8_t running_on_valgrind(void);
-static uint8_t const (*const shared_RUNNER_CTL_FIFO__3698)[21];
-static uint8_t const (*const shared_RUNNER_ACK_FIFO__3699)[21];
-static uint64_t const c_PROTOCOL_VERSION__236;
-static uint8_t const mem_native_endian__768;
-static uint8_t const os_linux_native_arch__2630;
-zig_extern int nanosleep(struct cimport_struct_timespec__3022 const *, struct cimport_struct_timespec__3022 *);
-static int const cimport_EINTR__5831;
-static uint8_t const fs_path_native_os__4236;
-static uint8_t const fs_native_os__1094;
-static uint8_t const fs_Dir_native_os__3822;
-static bool const fs_File_is_windows__1270;
-static uint8_t const posix_native_os__1280;
-zig_extern int clock_gettime(uint32_t, struct os_linux_timespec__struct_2843__2843 *);
-static uint8_t const builtin_mode__267;
+static uint8_t const (*const shared_RUNNER_CTL_FIFO__3701)[21];
+static uint8_t const (*const shared_RUNNER_ACK_FIFO__3702)[21];
+static uint64_t const c_PROTOCOL_VERSION__237;
+static uint8_t const mem_native_endian__769;
+zig_extern int printf(char const *, ...);
+zig_extern int fcntl(int, int, ...);
+static int const cimport_F_GETFL__5129;
+static int const cimport_O_NONBLOCK__5105;
+static int const cimport_F_SETFL__5130;
+static uint8_t const os_linux_native_arch__2633;
+zig_extern int nanosleep(struct cimport_struct_timespec__3100 const *, struct cimport_struct_timespec__3100 *);
+static int const cimport_EINTR__6758;
+zig_extern zig_noreturn void exit(int);
+static uint8_t const fs_path_native_os__4243;
+static uint8_t const fs_native_os__1097;
+static uint8_t const fs_Dir_native_os__3825;
+static bool const fs_File_is_windows__1273;
+static uint8_t const posix_native_os__1283;
+zig_extern int clock_gettime(uint32_t, struct os_linux_timespec__struct_2922__2922 *);
+static uint8_t const builtin_mode__268;
 static bool const debug_runtime_safety__159;
 zig_extern int flock(int32_t, int);
-static bool const fs_Dir_have_flock__3823;
+static bool const fs_Dir_have_flock__3826;
 zig_extern intptr_t write(int32_t, uint8_t const *, uintptr_t);
-static uint8_t const c_native_abi__1722;
+static uint8_t const c_native_abi__1725;
 zig_extern int *zig_e___errno_location(void) zig_mangled(zig_e___errno_location, "__errno_location");
-static bool const posix_unexpected_error_tracing__1711;
+static bool const posix_unexpected_error_tracing__1714;
 zig_extern intptr_t read(int32_t, uint8_t *, uintptr_t);
 zig_extern int faccessat(int32_t, uint8_t const *, unsigned int, unsigned int);
-static bool const posix_lfs64_abi__1710;
+static bool const posix_lfs64_abi__1713;
 zig_extern int openat64(int, uint8_t const *, uint32_t, ...);
 zig_extern int close(int32_t);
 zig_extern void callgrind_zero_stats(void);
 zig_extern void callgrind_start_instrumentation(void);
 zig_extern void callgrind_stop_instrumentation(void);
 zig_extern void callgrind_dump_stats_at(uint8_t const *);
-static bool const mem_backend_supports_vectors__796;
-static bool const builtin_valgrind_support__271;
+static bool const mem_backend_supports_vectors__797;
+static bool const builtin_valgrind_support__272;
 static bool const debug_default_enable_segfault_handler__205;
-static uint8_t const log_default_level__6375;
-static struct std_Options__4209 const std_options__97;
-static nav__3551_38 const heap_page_size_min_default__3551;
-static uintptr_t const heap_page_size_min__3530;
-static uint16_t const fmt_max_format_args__6443;
-static uint8_t const (*const fmt_ANY__6446)[4];
-static uint8_t const unicode_native_endian__6668;
-static uint32_t const unicode_replacement_character__6669;
-static uint8_t const c_MARKER_TYPE_SAMPLE_START__246;
-static uint8_t const c_MARKER_TYPE_SAMPLE_END__247;
-static uint8_t const c_MARKER_TYPE_BENCHMARK_START__248;
-static uint8_t const c_MARKER_TYPE_BENCHMARK_END__249;
-static struct mem_Allocator_VTable__568 const heap_CAllocator_vtable__3562;
+static uint8_t const log_default_level__7302;
+static struct std_Options__4269 const std_options__97;
+static nav__3554_38 const heap_page_size_min_default__3554;
+static uintptr_t const heap_page_size_min__3533;
+static uint16_t const fmt_max_format_args__7370;
+static uint8_t const (*const fmt_ANY__7373)[4];
+static uint8_t const unicode_native_endian__7595;
+static uint32_t const unicode_replacement_character__7596;
+static uint8_t const c_MARKER_TYPE_SAMPLE_START__247;
+static uint8_t const c_MARKER_TYPE_SAMPLE_END__248;
+static uint8_t const c_MARKER_TYPE_BENCHMARK_START__249;
+static uint8_t const c_MARKER_TYPE_BENCHMARK_END__250;
+static struct mem_Allocator_VTable__568 const heap_CAllocator_vtable__3565;
 zig_extern uintptr_t malloc_usable_size(void const *);
-static bool const heap_CAllocator_supports_malloc_size__3563;
-static bool const heap_CAllocator_supports_posix_memalign__3565;
+static bool const heap_CAllocator_supports_malloc_size__3566;
+static bool const heap_CAllocator_supports_posix_memalign__3568;
 zig_extern int posix_memalign(void **, uintptr_t, uintptr_t);
 zig_extern void free(void *);
-static struct Target_Cpu_Model__812 const Target_x86_cpu_alderlake__3594;
+static struct Target_Cpu_Model__812 const Target_x86_cpu_alderlake__3597;
 enum {
  zig_error_OutOfMemory = 1u,
  zig_error_PermissionDenied = 2u,
@@ -1144,19 +1157,21 @@ enum {
  zig_error_NotOpenForReading = 40u,
  zig_error_SocketNotConnected = 41u,
  zig_error_Canceled = 42u,
- zig_error_EndOfStream = 43u,
- zig_error_UnexpectedError = 44u,
- zig_error_UnexpectedResponse = 45u,
- zig_error_UnsupportedClock = 46u,
- zig_error_Overflow = 47u,
- zig_error_Utf8ExpectedContinuation = 48u,
- zig_error_Utf8OverlongEncoding = 49u,
- zig_error_Utf8EncodesSurrogateHalf = 50u,
- zig_error_Utf8CodepointTooLarge = 51u,
- zig_error_Utf8InvalidStartByte = 52u,
- zig_error_TruncatedInput = 53u,
- zig_error_Utf8CannotEncodeSurrogateHalf = 54u,
- zig_error_CodepointTooLarge = 55u,
+ zig_error_NotReady = 43u,
+ zig_error_UnexpectedEof = 44u,
+ zig_error_EndOfStream = 45u,
+ zig_error_UnexpectedError = 46u,
+ zig_error_UnexpectedResponse = 47u,
+ zig_error_UnsupportedClock = 48u,
+ zig_error_Overflow = 49u,
+ zig_error_Utf8ExpectedContinuation = 50u,
+ zig_error_Utf8OverlongEncoding = 51u,
+ zig_error_Utf8EncodesSurrogateHalf = 52u,
+ zig_error_Utf8CodepointTooLarge = 53u,
+ zig_error_Utf8InvalidStartByte = 54u,
+ zig_error_TruncatedInput = 55u,
+ zig_error_Utf8CannotEncodeSurrogateHalf = 56u,
+ zig_error_CodepointTooLarge = 57u,
 };
 static uint8_t const zig_errorName_OutOfMemory[12] = "OutOfMemory";
 static uint8_t const zig_errorName_PermissionDenied[17] = "PermissionDenied";
@@ -1200,6 +1215,8 @@ static uint8_t const zig_errorName_ConnectionTimedOut[19] = "ConnectionTimedOut"
 static uint8_t const zig_errorName_NotOpenForReading[18] = "NotOpenForReading";
 static uint8_t const zig_errorName_SocketNotConnected[19] = "SocketNotConnected";
 static uint8_t const zig_errorName_Canceled[9] = "Canceled";
+static uint8_t const zig_errorName_NotReady[9] = "NotReady";
+static uint8_t const zig_errorName_UnexpectedEof[14] = "UnexpectedEof";
 static uint8_t const zig_errorName_EndOfStream[12] = "EndOfStream";
 static uint8_t const zig_errorName_UnexpectedError[16] = "UnexpectedError";
 static uint8_t const zig_errorName_UnexpectedResponse[19] = "UnexpectedResponse";
@@ -1213,52 +1230,56 @@ static uint8_t const zig_errorName_Utf8InvalidStartByte[21] = "Utf8InvalidStartB
 static uint8_t const zig_errorName_TruncatedInput[15] = "TruncatedInput";
 static uint8_t const zig_errorName_Utf8CannotEncodeSurrogateHalf[30] = "Utf8CannotEncodeSurrogateHalf";
 static uint8_t const zig_errorName_CodepointTooLarge[18] = "CodepointTooLarge";
-static struct anon__lazy_57 const zig_errorName[56] = {{zig_errorName_OutOfMemory, 11ul}, {zig_errorName_PermissionDenied, 16ul}, {zig_errorName_FileNotFound, 12ul}, {zig_errorName_NameTooLong, 11ul}, {zig_errorName_InputOutput, 11ul}, {zig_errorName_SystemResources, 15ul}, {zig_errorName_BadPathName, 11ul}, {zig_errorName_FileBusy, 8ul}, {zig_errorName_SymLinkLoop, 11ul}, {zig_errorName_ReadOnlyFileSystem, 18ul}, {zig_errorName_InvalidUtf8, 11ul}, {zig_errorName_InvalidWtf8, 11ul}, {zig_errorName_Unexpected, 10ul}, {zig_errorName_SharingViolation, 16ul}, {zig_errorName_PathAlreadyExists, 17ul}, {zig_errorName_AccessDenied, 12ul}, {zig_errorName_PipeBusy, 8ul}, {zig_errorName_NoDevice, 8ul}, {zig_errorName_NetworkNotFound, 15ul}, {zig_errorName_AntivirusInterference, 21ul}, {zig_errorName_ProcessFdQuotaExceeded, 22ul}, {zig_errorName_SystemFdQuotaExceeded, 21ul}, {zig_errorName_FileTooBig, 10ul}, {zig_errorName_IsDir, 5ul}, {zig_errorName_NoSpaceLeft, 11ul}, {zig_errorName_NotDir, 6ul}, {zig_errorName_DeviceBusy, 10ul}, {zig_errorName_FileLocksNotSupported, 21ul}, {zig_errorName_WouldBlock, 10ul}, {zig_errorName_DiskQuota, 9ul}, {zig_errorName_InvalidArgument, 15ul}, {zig_errorName_BrokenPipe, 10ul}, {zig_errorName_OperationAborted, 16ul}, {zig_errorName_NotOpenForWriting, 17ul}, {zig_errorName_LockViolation, 13ul}, {zig_errorName_ConnectionResetByPeer, 21ul}, {zig_errorName_ProcessNotFound, 15ul}, {zig_errorName_AckTimeout, 10ul}, {zig_errorName_ConnectionTimedOut, 18ul}, {zig_errorName_NotOpenForReading, 17ul}, {zig_errorName_SocketNotConnected, 18ul}, {zig_errorName_Canceled, 8ul}, {zig_errorName_EndOfStream, 11ul}, {zig_errorName_UnexpectedError, 15ul}, {zig_errorName_UnexpectedResponse, 18ul}, {zig_errorName_UnsupportedClock, 16ul}, {zig_errorName_Overflow, 8ul}, {zig_errorName_Utf8ExpectedContinuation, 24ul}, {zig_errorName_Utf8OverlongEncoding, 20ul}, {zig_errorName_Utf8EncodesSurrogateHalf, 24ul}, {zig_errorName_Utf8CodepointTooLarge, 21ul}, {zig_errorName_Utf8InvalidStartByte, 20ul}, {zig_errorName_TruncatedInput, 14ul}, {zig_errorName_Utf8CannotEncodeSurrogateHalf, 29ul}, {zig_errorName_CodepointTooLarge, 17ul}};
+static struct anon__lazy_57 const zig_errorName[58] = {{zig_errorName_OutOfMemory, 11ul}, {zig_errorName_PermissionDenied, 16ul}, {zig_errorName_FileNotFound, 12ul}, {zig_errorName_NameTooLong, 11ul}, {zig_errorName_InputOutput, 11ul}, {zig_errorName_SystemResources, 15ul}, {zig_errorName_BadPathName, 11ul}, {zig_errorName_FileBusy, 8ul}, {zig_errorName_SymLinkLoop, 11ul}, {zig_errorName_ReadOnlyFileSystem, 18ul}, {zig_errorName_InvalidUtf8, 11ul}, {zig_errorName_InvalidWtf8, 11ul}, {zig_errorName_Unexpected, 10ul}, {zig_errorName_SharingViolation, 16ul}, {zig_errorName_PathAlreadyExists, 17ul}, {zig_errorName_AccessDenied, 12ul}, {zig_errorName_PipeBusy, 8ul}, {zig_errorName_NoDevice, 8ul}, {zig_errorName_NetworkNotFound, 15ul}, {zig_errorName_AntivirusInterference, 21ul}, {zig_errorName_ProcessFdQuotaExceeded, 22ul}, {zig_errorName_SystemFdQuotaExceeded, 21ul}, {zig_errorName_FileTooBig, 10ul}, {zig_errorName_IsDir, 5ul}, {zig_errorName_NoSpaceLeft, 11ul}, {zig_errorName_NotDir, 6ul}, {zig_errorName_DeviceBusy, 10ul}, {zig_errorName_FileLocksNotSupported, 21ul}, {zig_errorName_WouldBlock, 10ul}, {zig_errorName_DiskQuota, 9ul}, {zig_errorName_InvalidArgument, 15ul}, {zig_errorName_BrokenPipe, 10ul}, {zig_errorName_OperationAborted, 16ul}, {zig_errorName_NotOpenForWriting, 17ul}, {zig_errorName_LockViolation, 13ul}, {zig_errorName_ConnectionResetByPeer, 21ul}, {zig_errorName_ProcessNotFound, 15ul}, {zig_errorName_AckTimeout, 10ul}, {zig_errorName_ConnectionTimedOut, 18ul}, {zig_errorName_NotOpenForReading, 17ul}, {zig_errorName_SocketNotConnected, 18ul}, {zig_errorName_Canceled, 8ul}, {zig_errorName_NotReady, 8ul}, {zig_errorName_UnexpectedEof, 13ul}, {zig_errorName_EndOfStream, 11ul}, {zig_errorName_UnexpectedError, 15ul}, {zig_errorName_UnexpectedResponse, 18ul}, {zig_errorName_UnsupportedClock, 16ul}, {zig_errorName_Overflow, 8ul}, {zig_errorName_Utf8ExpectedContinuation, 24ul}, {zig_errorName_Utf8OverlongEncoding, 20ul}, {zig_errorName_Utf8EncodesSurrogateHalf, 24ul}, {zig_errorName_Utf8CodepointTooLarge, 21ul}, {zig_errorName_Utf8InvalidStartByte, 20ul}, {zig_errorName_TruncatedInput, 14ul}, {zig_errorName_Utf8CannotEncodeSurrogateHalf, 29ul}, {zig_errorName_CodepointTooLarge, 17ul}};
 
 static uint8_t const __anon_1845[21] = "/tmp/runner.ctl.fifo";
 
-static uint8_t const __anon_1905[21] = "/tmp/runner.ack.fifo";
+static uint8_t const __anon_1916[21] = "/tmp/runner.ack.fifo";
 
-static uint8_t const __anon_2896[89] = "Invalid protocol detected: The stream end was found before all required bytes were read.";
+static uint8_t const __anon_2757[70] = "[ERROR] instrument-hooks: failed to communicate with CodSpeed runner\n";
 
-static uint8_t const __anon_4607[10] = "Metadata: ";
+static uint8_t const __anon_2761[83] = "[ERROR] instrument-hooks: please update the CodSpeed action to the latest version\n";
 
-static uint8_t const __anon_4888[1] = " ";
+static uint8_t const __anon_3003[89] = "Invalid protocol detected: The stream end was found before all required bytes were read.";
 
-static uint8_t const __anon_4908[1] = "\000";
+static uint8_t const __anon_4667[10] = "Metadata: ";
 
-static uint8_t const __anon_5079[3] = "\357\277\275";
+static uint8_t const __anon_4948[1] = " ";
 
-static uint8_t const __anon_4953[4] = "any";
+static uint8_t const __anon_4968[1] = "\000";
 
-static uint8_t const __anon_5232[10] = "alderlake";
+static uint8_t const __anon_5138[3] = "\357\277\275";
 
-void c_instrument_hooks_set_feature__237(uint64_t const a0, bool const a1) {
+static uint8_t const __anon_5013[4] = "any";
+
+static uint8_t const __anon_5291[10] = "alderlake";
+
+void c_instrument_hooks_set_feature__238(uint64_t const a0, bool const a1) {
  uint64_t t0;
  t0 = a0;
- features_set_feature__324(t0, a1);
+ features_set_feature__325(t0, a1);
  return;
 }
 
-static void features_set_feature__324(uint64_t const a0, bool const a1) {
+static void features_set_feature__325(uint64_t const a0, bool const a1) {
  uint64_t t0;
  uintptr_t t1;
  if (a1) {
   t0 = a0;
   t1 = t0;
-  bit_set_IntegerBitSet_2864_29_set__363(&features_features__323, t1);
+  bit_set_IntegerBitSet_2864_29_set__364(&features_features__324, t1);
   goto zig_block_0;
  }
  t0 = a0;
  t1 = t0;
- bit_set_IntegerBitSet_2864_29_unset__365(&features_features__323, t1);
+ bit_set_IntegerBitSet_2864_29_unset__366(&features_features__324, t1);
  goto zig_block_0;
 
  zig_block_0:;
  return;
 }
 
-static void bit_set_IntegerBitSet_2864_29_set__363(uint64_t *const a0, uintptr_t const a1) {
+static void bit_set_IntegerBitSet_2864_29_set__364(uint64_t *const a0, uintptr_t const a1) {
  uint64_t *const *t1;
  uint64_t t2;
  uint64_t t5;
@@ -1273,13 +1294,13 @@ static void bit_set_IntegerBitSet_2864_29_set__363(uint64_t *const a0, uintptr_t
  t4 = (*t1);
  t4 = (uint64_t *)((uint8_t *)t4 + (uintptr_t)0ul);
  t2 = (*t4);
- t5 = bit_set_IntegerBitSet_2864_29_maskBit__384(a1);
+ t5 = bit_set_IntegerBitSet_2864_29_maskBit__385(a1);
  t5 = t2 | t5;
  (*t4) = t5;
  return;
 }
 
-static void bit_set_IntegerBitSet_2864_29_unset__365(uint64_t *const a0, uintptr_t const a1) {
+static void bit_set_IntegerBitSet_2864_29_unset__366(uint64_t *const a0, uintptr_t const a1) {
  uint64_t *const *t1;
  uint64_t t2;
  uint64_t t5;
@@ -1294,7 +1315,7 @@ static void bit_set_IntegerBitSet_2864_29_unset__365(uint64_t *const a0, uintptr
  t4 = (*t1);
  t4 = (uint64_t *)((uint8_t *)t4 + (uintptr_t)0ul);
  t2 = (*t4);
- t5 = bit_set_IntegerBitSet_2864_29_maskBit__384(a1);
+ t5 = bit_set_IntegerBitSet_2864_29_maskBit__385(a1);
  t5 = zig_not_u64(t5, UINT8_C(64));
  t5 = t2 & t5;
  (*t4) = t5;
@@ -1313,7 +1334,7 @@ static void debug_assert__180(bool const a0) {
  return;
 }
 
-static uint64_t bit_set_IntegerBitSet_2864_29_maskBit__384(uintptr_t const a0) {
+static uint64_t bit_set_IntegerBitSet_2864_29_maskBit__385(uintptr_t const a0) {
  uint64_t t1;
  uint8_t t0;
  t0 = (uint8_t)a0;
@@ -1321,68 +1342,82 @@ static uint64_t bit_set_IntegerBitSet_2864_29_maskBit__384(uintptr_t const a0) {
  return t1;
 }
 
-static nav__1073_39 fifo_UnixPipe_openWrite__1073(struct mem_Allocator__565 const a0, nav__1073_42 const a1) {
- nav__1073_39 t1;
+static nav__1074_39 fifo_UnixPipe_openPipe__1074(nav__1074_41 const a0) {
+ nav__1074_39 t1;
+ struct fs_File__608 t2;
+ int32_t t3;
+ uint16_t t0;
+ t0 = fs_accessAbsolute__1142(a0, (struct fs_File_OpenFlags__1858){UINT8_C(2),UINT8_C(0),false,false});
+ if (t0) {
+  t1.payload = (struct fs_File__608){-INT32_C(0x55555556)};
+  t1.error = t0;
+  return t1;
+ }
+ t1 = fs_openFileAbsolute__1139(a0, (struct fs_File_OpenFlags__1858){UINT8_C(2),UINT8_C(0),false,false});
+ if (t1.error) {
+  t0 = t1.error;
+  t1.payload = (struct fs_File__608){-INT32_C(0x55555556)};
+  t1.error = t0;
+  return t1;
+ }
+ t2 = t1.payload;
+ t3 = t2.handle;
+ utils_setNonBlocking__3833(t3);
+ t1.payload = t2;
+ t1.error = UINT16_C(0);
+ return t1;
+}
+
+static nav__1076_39 fifo_UnixPipe_openWrite__1076(struct mem_Allocator__565 const a0, nav__1076_42 const a1) {
+ nav__1076_39 t2;
  struct fifo_UnixPipe_Writer__600 t4;
- nav__1073_56 t2;
+ nav__1076_54 t0;
  struct fs_File__608 t3;
- uint16_t t0;
- t0 = fs_accessAbsolute__1139(a1, (struct fs_File_OpenFlags__1852){UINT8_C(2),UINT8_C(0),false,false});
- if (t0) {
-  t1.payload = (struct fifo_UnixPipe_Writer__600){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}};
-  t1.error = t0;
-  return t1;
+ uint16_t t1;
+ t0 = fifo_UnixPipe_openPipe__1074(a1);
+ if (t0.error) {
+  t1 = t0.error;
+  t2.payload = (struct fifo_UnixPipe_Writer__600){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}};
+  t2.error = t1;
+  return t2;
  }
- t2 = fs_openFileAbsolute__1136(a1, (struct fs_File_OpenFlags__1852){UINT8_C(2),UINT8_C(1),true,false});
- if (t2.error) {
-  t0 = t2.error;
-  t1.payload = (struct fifo_UnixPipe_Writer__600){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}};
-  t1.error = t0;
-  return t1;
- }
- t3 = t2.payload;
- t4 = fifo_UnixPipe_Writer_init__1074(t3, a0);
- t1.payload = t4;
- t1.error = UINT16_C(0);
- return t1;
+ t3 = t0.payload;
+ t4 = fifo_UnixPipe_Writer_init__1077(t3, a0);
+ t2.payload = t4;
+ t2.error = UINT16_C(0);
+ return t2;
 }
 
-static nav__1072_39 fifo_UnixPipe_openRead__1072(struct mem_Allocator__565 const a0, nav__1072_42 const a1) {
- nav__1072_39 t1;
+static nav__1075_39 fifo_UnixPipe_openRead__1075(struct mem_Allocator__565 const a0, nav__1075_42 const a1) {
+ nav__1075_39 t2;
  struct fifo_UnixPipe_Reader__602 t4;
- nav__1072_56 t2;
+ nav__1075_54 t0;
  struct fs_File__608 t3;
- uint16_t t0;
- t0 = fs_accessAbsolute__1139(a1, (struct fs_File_OpenFlags__1852){UINT8_C(2),UINT8_C(0),false,false});
- if (t0) {
-  t1.payload = (struct fifo_UnixPipe_Reader__602){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}};
-  t1.error = t0;
-  return t1;
+ uint16_t t1;
+ t0 = fifo_UnixPipe_openPipe__1074(a1);
+ if (t0.error) {
+  t1 = t0.error;
+  t2.payload = (struct fifo_UnixPipe_Reader__602){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}};
+  t2.error = t1;
+  return t2;
  }
- t2 = fs_openFileAbsolute__1136(a1, (struct fs_File_OpenFlags__1852){UINT8_C(2),UINT8_C(1),true,false});
- if (t2.error) {
-  t0 = t2.error;
-  t1.payload = (struct fifo_UnixPipe_Reader__602){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}};
-  t1.error = t0;
-  return t1;
- }
- t3 = t2.payload;
- t4 = fifo_UnixPipe_Reader_init__1079(t3, a0);
- t1.payload = t4;
- t1.error = UINT16_C(0);
- return t1;
+ t3 = t0.payload;
+ t4 = fifo_UnixPipe_Reader_init__1082(t3, a0);
+ t2.payload = t4;
+ t2.error = UINT16_C(0);
+ return t2;
 }
 
-static nav__750_39 instruments_perf_PerfInstrument_init__750(struct mem_Allocator__565 const a0) {
+static nav__751_39 instruments_perf_PerfInstrument_init__751(struct mem_Allocator__565 const a0) {
  struct instruments_perf_PerfInstrument__559 *t1;
  struct mem_Allocator__565 *t2;
  struct fifo_UnixPipe_Writer__600 *t3;
- nav__750_61 t4;
- nav__750_39 t6;
- nav__750_39 t0;
+ nav__751_61 t4;
+ nav__751_39 t6;
+ nav__751_39 t0;
  struct fifo_UnixPipe_Writer__600 t7;
  struct fifo_UnixPipe_Reader__602 *t8;
- nav__750_66 t9;
+ nav__751_66 t9;
  struct fifo_UnixPipe_Reader__602 t10;
  uint16_t t5;
  t0.error = UINT16_C(0);
@@ -1390,7 +1425,7 @@ static nav__750_39 instruments_perf_PerfInstrument_init__750(struct mem_Allocato
  t2 = (struct mem_Allocator__565 *)&t1->allocator;
  (*t2) = a0;
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t1->writer;
- t4 = fifo_UnixPipe_openWrite__1073(a0, (nav__750_59){(uint8_t const *)&__anon_1845,(uintptr_t)20ul});
+ t4 = fifo_UnixPipe_openWrite__1076(a0, (nav__751_59){(uint8_t const *)&__anon_1845,(uintptr_t)20ul});
  if (t4.error) {
   t5 = t4.error;
   t6.payload = (struct instruments_perf_PerfInstrument__559){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}},{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}}};
@@ -1400,7 +1435,7 @@ static nav__750_39 instruments_perf_PerfInstrument_init__750(struct mem_Allocato
  t7 = t4.payload;
  (*t3) = t7;
  t8 = (struct fifo_UnixPipe_Reader__602 *)&t1->reader;
- t9 = fifo_UnixPipe_openRead__1072(a0, (nav__750_59){(uint8_t const *)&__anon_1905,(uintptr_t)20ul});
+ t9 = fifo_UnixPipe_openRead__1075(a0, (nav__751_59){(uint8_t const *)&__anon_1916,(uintptr_t)20ul});
  if (t9.error) {
   t5 = t9.error;
   t6.payload = (struct instruments_perf_PerfInstrument__559){{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}},{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)},{-INT32_C(0x55555556)}}};
@@ -1412,20 +1447,20 @@ static nav__750_39 instruments_perf_PerfInstrument_init__750(struct mem_Allocato
  return t0;
 }
 
-static nav__725_39 instruments_root_InstrumentHooks_init__725(struct mem_Allocator__565 const a0) {
+static nav__726_39 instruments_root_InstrumentHooks_init__726(struct mem_Allocator__565 const a0) {
  struct instruments_valgrind_ValgrindInstrument__554 t2;
  struct instruments_root_InstrumentHooks__547 t3;
- nav__725_39 t4;
+ nav__726_39 t4;
  struct instruments_perf_PerfInstrument__559 t6;
  struct instruments_perf_PerfInstrument__559 t8;
  struct instruments_perf_PerfInstrument__559 t5;
- nav__725_60 t7;
+ nav__726_60 t7;
  uint8_t t0;
  bool t1;
  t0 = running_on_valgrind();
  t1 = t0 > UINT8_C(0);
  if (t1) {
-  t2 = instruments_valgrind_ValgrindInstrument_init__738(a0);
+  t2 = instruments_valgrind_ValgrindInstrument_init__739(a0);
   t3.tag = UINT8_C(0);
   t3.payload.valgrind = t2;
   t4.payload = t3;
@@ -1435,18 +1470,18 @@ static nav__725_39 instruments_root_InstrumentHooks_init__725(struct mem_Allocat
  goto zig_block_0;
 
  zig_block_0:;
- t7 = instruments_perf_PerfInstrument_init__750(a0);
+ t7 = instruments_perf_PerfInstrument_init__751(a0);
  t1 = t7.error == UINT16_C(0);
  if (t1) {
   t8 = t7.payload;
   t6 = t8;
   goto zig_block_1;
  }
- return (nav__725_39){{{{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)}}},UINT8_C(2)},0};
+ return (nav__726_39){{{{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)}}},UINT8_C(2)},0};
 
  zig_block_1:;
  t5 = t6;
- t1 = instruments_perf_PerfInstrument_is_instrumented__753(&t5);
+ t1 = instruments_perf_PerfInstrument_is_instrumented__754(&t5);
  if (t1) {
   t6 = t5;
   t3.tag = UINT8_C(1);
@@ -1458,24 +1493,24 @@ static nav__725_39 instruments_root_InstrumentHooks_init__725(struct mem_Allocat
  goto zig_block_2;
 
  zig_block_2:;
- return (nav__725_39){{{{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)}}},UINT8_C(2)},0};
+ return (nav__726_39){{{{{((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul)}}},UINT8_C(2)},0};
 }
 
-static uint16_t fifo_UnixPipe_Writer_sendCmd__1077(struct fifo_UnixPipe_Writer__600 *const a0, struct shared_Command__1935 const a1) {
+static uint16_t fifo_UnixPipe_Writer_sendCmd__1080(struct fifo_UnixPipe_Writer__600 *const a0, struct shared_Command__1946 const a1) {
  struct fifo_UnixPipe_Writer__600 *const *t1;
  struct mem_Allocator__565 *t3;
  struct mem_Allocator__565 t4;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t5;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t2;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t6;
- nav__1077_60 t8;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t5;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t2;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t6;
+ nav__1080_60 t8;
  struct fifo_UnixPipe_Writer__600 *t9;
  struct fifo_UnixPipe_Writer__600 *t0;
  struct fs_File__608 *t10;
  uintptr_t t12;
  uint32_t const *t15;
  uint8_t const (*t16)[4];
- nav__1077_44 t17;
+ nav__1080_44 t17;
  struct fs_File__608 t11;
  uint32_t t13;
  uint32_t t14;
@@ -1484,13 +1519,13 @@ static uint16_t fifo_UnixPipe_Writer_sendCmd__1077(struct fifo_UnixPipe_Writer__
  t1 = (struct fifo_UnixPipe_Writer__600 *const *)&t0;
  t3 = (struct mem_Allocator__565 *)&a0->allocator;
  t4 = (*t3);
- t5 = array_list_ArrayListAligned_28u8_2cnull_29_init__3876(t4);
+ t5 = array_list_ArrayListAligned_28u8_2cnull_29_init__3888(t4);
  t2 = t5;
- t6 = array_list_ArrayListAligned_28u8_2cnull_29_writer__3901(&t2);
- t7 = bincode_serialize__anon_2004__4049(t6, a1);
+ t6 = array_list_ArrayListAligned_28u8_2cnull_29_writer__3913(&t2);
+ t7 = bincode_serialize__anon_2015__4061(t6, a1);
  if (t7) {
   t5 = t2;
-  array_list_ArrayListAligned_28u8_2cnull_29_deinit__3878(t5);
+  array_list_ArrayListAligned_28u8_2cnull_29_deinit__3890(t5);
   return t7;
  }
  t5 = t2;
@@ -1502,76 +1537,76 @@ static uint16_t fifo_UnixPipe_Writer_sendCmd__1077(struct fifo_UnixPipe_Writer__
  t13 = (uint32_t)t12;
  t14 = t13;
  t15 = (uint32_t const *)&t14;
- t16 = mem_asBytes__anon_2046__4050(t15);
+ t16 = mem_asBytes__anon_2057__4062(t15);
  t17.ptr = &(*t16)[(uintptr_t)0ul];
  t17.len = (uintptr_t)4ul;
- t7 = fs_File_writeAll__1230(t11, t17);
+ t7 = fs_File_writeAll__1233(t11, t17);
  if (t7) {
   t5 = t2;
-  array_list_ArrayListAligned_28u8_2cnull_29_deinit__3878(t5);
+  array_list_ArrayListAligned_28u8_2cnull_29_deinit__3890(t5);
   return t7;
  }
  t9 = (*t1);
  t10 = (struct fs_File__608 *)&t9->file;
  t11 = (*t10);
- memcpy(&t17, &t8, sizeof(nav__1077_44));
- t7 = fs_File_writeAll__1230(t11, t17);
+ memcpy(&t17, &t8, sizeof(nav__1080_44));
+ t7 = fs_File_writeAll__1233(t11, t17);
  if (t7) {
   t5 = t2;
-  array_list_ArrayListAligned_28u8_2cnull_29_deinit__3878(t5);
+  array_list_ArrayListAligned_28u8_2cnull_29_deinit__3890(t5);
   return t7;
  }
  t5 = t2;
- array_list_ArrayListAligned_28u8_2cnull_29_deinit__3878(t5);
+ array_list_ArrayListAligned_28u8_2cnull_29_deinit__3890(t5);
  return 0;
 }
 
-static nav__4160_38 bincode_deserializeInt__anon_2292__4160(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0) {
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t1;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t4;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t2;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t0;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t3;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *t5;
+static nav__4173_38 bincode_deserializeInt__anon_2322__4173(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0) {
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t1;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t4;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t2;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t0;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t3;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *t5;
  void const **t7;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t8;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t8;
  void const *t9;
- nav__4160_50 (**t10)(void const *, nav__4160_52);
- struct io_Reader__2307 t11;
- struct io_Reader__2307 t6;
- struct io_Reader__2307 t12;
- struct io_Reader__2307 t15;
- struct io_Reader__2307 const *t13;
+ nav__4173_50 (**t10)(void const *, nav__4173_52);
+ struct io_Reader__2337 t11;
+ struct io_Reader__2337 t6;
+ struct io_Reader__2337 t12;
+ struct io_Reader__2337 t15;
+ struct io_Reader__2337 const *t13;
  uint8_t const (*t21)[4];
- nav__4160_38 t14;
- nav__4160_38 t18;
+ nav__4173_38 t14;
+ nav__4173_38 t18;
  uint32_t t22;
- nav__4160_64 t16;
+ nav__4173_64 t16;
  uint16_t t17;
  uint8_t t19[4];
  uint8_t t20[4];
  t0 = a0;
- t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t0;
+ t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t0;
  t2 = (*t1);
  t3 = t2;
- t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t3;
+ t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t3;
  t4 = t1;
- t5 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *)&t4;
+ t5 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *)&t4;
  t7 = (void const **)&t6.context;
  t1 = (*t5);
- t8 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t1->context;
+ t8 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t1->context;
  t9 = (void const *)t8;
  (*t7) = t9;
- t10 = (nav__4160_50 (**)(void const *, nav__4160_52))&t6.readFn;
- (*t10) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4156;
+ t10 = (nav__4173_50 (**)(void const *, nav__4173_52))&t6.readFn;
+ (*t10) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4169;
  t11 = t6;
  t12 = t11;
- t13 = (struct io_Reader__2307 const *)&t12;
+ t13 = (struct io_Reader__2337 const *)&t12;
  t11 = (*t13);
  t15 = t11;
- t13 = (struct io_Reader__2307 const *)&t15;
+ t13 = (struct io_Reader__2337 const *)&t15;
  t11 = (*t13);
- t16 = io_Reader_readBytesNoEof__anon_2338__4198(t11);
+ t16 = io_Reader_readBytesNoEof__anon_2368__4211(t11);
  if (t16.error) {
   t17 = t16.error;
   t18.payload = UINT32_C(0xaaaaaaaa);
@@ -1591,7 +1626,7 @@ static nav__4160_38 bincode_deserializeInt__anon_2292__4160(struct io_GenericRea
  goto zig_block_0;
 
  zig_block_0:;
- memcpy(&t18, &t14, sizeof(nav__4160_38));
+ memcpy(&t18, &t14, sizeof(nav__4173_38));
  if (t18.error) {
   t17 = t18.error;
   t18.payload = UINT32_C(0xaaaaaaaa);
@@ -1604,12 +1639,12 @@ static nav__4160_38 bincode_deserializeInt__anon_2292__4160(struct io_GenericRea
  return t18;
 }
 
-static nav__4159_38 bincode_deserializeAlloc__anon_2281__4159(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4159_38 t0;
+static nav__4172_38 bincode_deserializeAlloc__anon_2311__4172(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4172_38 t0;
  uint32_t t2;
  uint16_t t1;
  (void)a1;
- t0 = bincode_deserializeInt__anon_2292__4160(a0);
+ t0 = bincode_deserializeInt__anon_2322__4173(a0);
  if (t0.error) {
   t1 = t0.error;
   t0.payload = UINT32_C(0xaaaaaaaa);
@@ -1622,71 +1657,71 @@ static nav__4159_38 bincode_deserializeAlloc__anon_2281__4159(struct io_GenericR
  return t0;
 }
 
-static nav__4202_40 bincode_deserializePointerAlloc__anon_2418__4202(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t1;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t6;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t7;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t32;
+static nav__4215_40 bincode_deserializePointerAlloc__anon_2448__4215(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t1;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t6;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t7;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t32;
  struct mem_Allocator__565 const *t3;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t4;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t0;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t5;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t31;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *t8;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t4;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t0;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t5;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t31;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *t8;
  void const **t10;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t11;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t11;
  void const *t12;
- nav__4202_59 (**t13)(void const *, nav__4202_39);
- struct io_Reader__2307 t14;
- struct io_Reader__2307 t9;
- struct io_Reader__2307 t15;
- struct io_Reader__2307 t18;
- struct io_Reader__2307 t33;
- struct io_Reader__2307 t34;
- struct io_Reader__2307 const *t16;
- nav__4202_69 t17;
- nav__4202_69 t21;
+ nav__4215_59 (**t13)(void const *, nav__4215_39);
+ struct io_Reader__2337 t14;
+ struct io_Reader__2337 t9;
+ struct io_Reader__2337 t15;
+ struct io_Reader__2337 t18;
+ struct io_Reader__2337 t33;
+ struct io_Reader__2337 t34;
+ struct io_Reader__2337 const *t16;
+ nav__4215_69 t17;
+ nav__4215_69 t21;
  uint8_t const (*t24)[8];
  uint64_t t25;
  uint64_t t38;
- nav__4202_40 t26;
+ nav__4215_40 t26;
  uintptr_t t27;
  uintptr_t t37;
  struct mem_Allocator__565 t29;
  struct mem_Allocator__565 t2;
- nav__4202_39 t30;
- nav__4202_39 t28;
- nav__4202_59 t35;
- nav__4202_59 t36;
- nav__4202_72 t19;
+ nav__4215_39 t30;
+ nav__4215_39 t28;
+ nav__4215_59 t35;
+ nav__4215_59 t36;
+ nav__4215_72 t19;
  uint16_t t20;
  uint8_t t22[8];
  uint8_t t23[8];
  bool t39;
  t0 = a0;
- t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t0;
+ t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t0;
  t2 = a1;
  t3 = (struct mem_Allocator__565 const *)&t2;
  t4 = (*t1);
  t5 = t4;
- t6 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t5;
+ t6 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t5;
  t7 = t6;
- t8 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *)&t7;
+ t8 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *)&t7;
  t10 = (void const **)&t9.context;
  t6 = (*t8);
- t11 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t6->context;
+ t11 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t6->context;
  t12 = (void const *)t11;
  (*t10) = t12;
- t13 = (nav__4202_59 (**)(void const *, nav__4202_39))&t9.readFn;
- (*t13) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4156;
+ t13 = (nav__4215_59 (**)(void const *, nav__4215_39))&t9.readFn;
+ (*t13) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4169;
  t14 = t9;
  t15 = t14;
- t16 = (struct io_Reader__2307 const *)&t15;
+ t16 = (struct io_Reader__2337 const *)&t15;
  t14 = (*t16);
  t18 = t14;
- t16 = (struct io_Reader__2307 const *)&t18;
+ t16 = (struct io_Reader__2337 const *)&t18;
  t14 = (*t16);
- t19 = io_Reader_readBytesNoEof__anon_2431__4203(t14);
+ t19 = io_Reader_readBytesNoEof__anon_2461__4216(t14);
  if (t19.error) {
   t20 = t19.error;
   t21.payload = UINT64_C(0xaaaaaaaaaaaaaaaa);
@@ -1706,20 +1741,20 @@ static nav__4202_40 bincode_deserializePointerAlloc__anon_2418__4202(struct io_G
  goto zig_block_0;
 
  zig_block_0:;
- memcpy(&t21, &t17, sizeof(nav__4202_69));
+ memcpy(&t21, &t17, sizeof(nav__4215_69));
  if (t21.error) {
   t20 = t21.error;
-  t26.payload = (nav__4202_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t26.payload = (nav__4215_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t26.error = t20;
   return t26;
  }
  t25 = t21.payload;
  t27 = t25;
  t29 = (*t3);
- t26 = mem_Allocator_alloc__anon_2129__4091(t29, t27);
+ t26 = mem_Allocator_alloc__anon_2153__4103(t29, t27);
  if (t26.error) {
   t20 = t26.error;
-  t26.payload = (nav__4202_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t26.payload = (nav__4215_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t26.error = t20;
   return t26;
  }
@@ -1728,28 +1763,28 @@ static nav__4202_40 bincode_deserializePointerAlloc__anon_2418__4202(struct io_G
  t4 = (*t1);
  t30 = t28;
  t31 = t4;
- t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t31;
+ t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t31;
  t32 = t1;
- t8 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *)&t32;
+ t8 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *)&t32;
  t10 = (void const **)&t33.context;
  t1 = (*t8);
- t11 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t1->context;
+ t11 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t1->context;
  t12 = (void const *)t11;
  (*t10) = t12;
- t13 = (nav__4202_59 (**)(void const *, nav__4202_39))&t33.readFn;
- (*t13) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4156;
+ t13 = (nav__4215_59 (**)(void const *, nav__4215_39))&t33.readFn;
+ (*t13) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4169;
  t14 = t33;
  t34 = t14;
- t16 = (struct io_Reader__2307 const *)&t34;
+ t16 = (struct io_Reader__2337 const *)&t34;
  t14 = (*t16);
- t35 = io_Reader_readAll__4163(t14, t30);
- memcpy(&t36, &t35, sizeof(nav__4202_59));
+ t35 = io_Reader_readAll__4176(t14, t30);
+ memcpy(&t36, &t35, sizeof(nav__4215_59));
  t37 = t36.payload;
  t25 = t37;
  t38 = t27;
  t39 = t25 != t38;
  if (t39) {
-  bincode_invalidProtocol__anon_2455__4204();
+  bincode_invalidProtocol__anon_2485__4217();
   zig_unreachable();
  }
  goto zig_block_1;
@@ -1761,52 +1796,52 @@ static nav__4202_40 bincode_deserializePointerAlloc__anon_2418__4202(struct io_G
  return t26;
 }
 
-static nav__4201_40 bincode_deserializeAlloc__anon_2405__4201(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4201_57 t0;
- nav__4201_40 t2;
- nav__4201_55 t3;
- nav__4201_39 t4;
+static nav__4214_40 bincode_deserializeAlloc__anon_2435__4214(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4214_57 t0;
+ nav__4214_40 t2;
+ nav__4214_55 t3;
+ nav__4214_39 t4;
  uint16_t t1;
- t0 = bincode_deserializePointerAlloc__anon_2418__4202(a0, a1);
+ t0 = bincode_deserializePointerAlloc__anon_2448__4215(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t2.payload = (nav__4201_39){(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t2.payload = (nav__4214_39){(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t2.error = t1;
   return t2;
  }
  t3 = t0.payload;
- memcpy(&t4, &t3, sizeof(nav__4201_39));
+ memcpy(&t4, &t3, sizeof(nav__4214_39));
  t2.payload = t4;
  t2.error = UINT16_C(0);
  return t2;
 }
 
-static nav__4200_39 bincode_deserializeStructAlloc__anon_2380__4200(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
+static nav__4213_39 bincode_deserializeStructAlloc__anon_2410__4213(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
  uint32_t *t1;
- nav__4200_39 t4;
- nav__4200_44 *t6;
- nav__4200_60 t7;
- nav__4200_44 t8;
- struct shared_Command__struct_1938__1938 t9;
- struct shared_Command__struct_1938__1938 t0;
- nav__4200_57 t2;
+ nav__4213_39 t4;
+ nav__4213_44 *t6;
+ nav__4213_60 t7;
+ nav__4213_44 t8;
+ struct shared_Command__struct_1949__1949 t9;
+ struct shared_Command__struct_1949__1949 t0;
+ nav__4213_57 t2;
  uint32_t t5;
  uint16_t t3;
  t1 = (uint32_t *)&t0.pid;
- t2 = bincode_deserializeAlloc__anon_2281__4159(a0, a1);
+ t2 = bincode_deserializeAlloc__anon_2311__4172(a0, a1);
  if (t2.error) {
   t3 = t2.error;
-  t4.payload = (struct shared_Command__struct_1938__1938){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)};
+  t4.payload = (struct shared_Command__struct_1949__1949){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)};
   t4.error = t3;
   return t4;
  }
  t5 = t2.payload;
  (*t1) = t5;
- t6 = (nav__4200_44 *)&t0.uri;
- t7 = bincode_deserializeAlloc__anon_2405__4201(a0, a1);
+ t6 = (nav__4213_44 *)&t0.uri;
+ t7 = bincode_deserializeAlloc__anon_2435__4214(a0, a1);
  if (t7.error) {
   t3 = t7.error;
-  t4.payload = (struct shared_Command__struct_1938__1938){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)};
+  t4.payload = (struct shared_Command__struct_1949__1949){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)};
   t4.error = t3;
   return t4;
  }
@@ -1818,14 +1853,14 @@ static nav__4200_39 bincode_deserializeStructAlloc__anon_2380__4200(struct io_Ge
  return t4;
 }
 
-static nav__4199_39 bincode_deserializeAlloc__anon_2351__4199(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4199_39 t0;
- struct shared_Command__struct_1938__1938 t2;
+static nav__4212_39 bincode_deserializeAlloc__anon_2381__4212(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4212_39 t0;
+ struct shared_Command__struct_1949__1949 t2;
  uint16_t t1;
- t0 = bincode_deserializeStructAlloc__anon_2380__4200(a0, a1);
+ t0 = bincode_deserializeStructAlloc__anon_2410__4213(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t0.payload = (struct shared_Command__struct_1938__1938){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)};
+  t0.payload = (struct shared_Command__struct_1949__1949){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)};
   t0.error = t1;
   return t0;
  }
@@ -1835,35 +1870,35 @@ static nav__4199_39 bincode_deserializeAlloc__anon_2351__4199(struct io_GenericR
  return t0;
 }
 
-static uint16_t bincode_deserializeAlloc__anon_2470__4205(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
+static uint16_t bincode_deserializeAlloc__anon_2500__4218(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
  (void)a0;
  (void)a1;
  return 0;
 }
 
-static nav__4207_39 bincode_deserializeStructAlloc__anon_2534__4207(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4207_44 *t1;
- nav__4207_57 t2;
- nav__4207_39 t4;
- nav__4207_44 t5;
- struct shared_Command__struct_1939__1939 t6;
- struct shared_Command__struct_1939__1939 t0;
+static nav__4220_39 bincode_deserializeStructAlloc__anon_2564__4220(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4220_44 *t1;
+ nav__4220_57 t2;
+ nav__4220_39 t4;
+ nav__4220_44 t5;
+ struct shared_Command__struct_1950__1950 t6;
+ struct shared_Command__struct_1950__1950 t0;
  uint16_t t3;
- t1 = (nav__4207_44 *)&t0.name;
- t2 = bincode_deserializeAlloc__anon_2405__4201(a0, a1);
+ t1 = (nav__4220_44 *)&t0.name;
+ t2 = bincode_deserializeAlloc__anon_2435__4214(a0, a1);
  if (t2.error) {
   t3 = t2.error;
-  t4.payload = (struct shared_Command__struct_1939__1939){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul}};
+  t4.payload = (struct shared_Command__struct_1950__1950){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul}};
   t4.error = t3;
   return t4;
  }
  t5 = t2.payload;
  (*t1) = t5;
- t1 = (nav__4207_44 *)&t0.version;
- t2 = bincode_deserializeAlloc__anon_2405__4201(a0, a1);
+ t1 = (nav__4220_44 *)&t0.version;
+ t2 = bincode_deserializeAlloc__anon_2435__4214(a0, a1);
  if (t2.error) {
   t3 = t2.error;
-  t4.payload = (struct shared_Command__struct_1939__1939){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul}};
+  t4.payload = (struct shared_Command__struct_1950__1950){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul}};
   t4.error = t3;
   return t4;
  }
@@ -1875,14 +1910,14 @@ static nav__4207_39 bincode_deserializeStructAlloc__anon_2534__4207(struct io_Ge
  return t4;
 }
 
-static nav__4206_39 bincode_deserializeAlloc__anon_2515__4206(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4206_39 t0;
- struct shared_Command__struct_1939__1939 t2;
+static nav__4219_39 bincode_deserializeAlloc__anon_2545__4219(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4219_39 t0;
+ struct shared_Command__struct_1950__1950 t2;
  uint16_t t1;
- t0 = bincode_deserializeStructAlloc__anon_2534__4207(a0, a1);
+ t0 = bincode_deserializeStructAlloc__anon_2564__4220(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t0.payload = (struct shared_Command__struct_1939__1939){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul}};
+  t0.payload = (struct shared_Command__struct_1950__1950){{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul}};
   t0.error = t1;
   return t0;
  }
@@ -1892,52 +1927,52 @@ static nav__4206_39 bincode_deserializeAlloc__anon_2515__4206(struct io_GenericR
  return t0;
 }
 
-static nav__4213_38 bincode_deserializeInt__anon_2657__4213(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0) {
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t1;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *t4;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t2;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t0;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t3;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *t5;
+static nav__4226_38 bincode_deserializeInt__anon_2687__4226(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0) {
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t1;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *t4;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t2;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t0;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t3;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *t5;
  void const **t7;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t8;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t8;
  void const *t9;
- nav__4213_50 (**t10)(void const *, nav__4213_52);
- struct io_Reader__2307 t11;
- struct io_Reader__2307 t6;
- struct io_Reader__2307 t12;
- struct io_Reader__2307 t15;
- struct io_Reader__2307 const *t13;
- nav__4213_38 t14;
- nav__4213_38 t18;
+ nav__4226_50 (**t10)(void const *, nav__4226_52);
+ struct io_Reader__2337 t11;
+ struct io_Reader__2337 t6;
+ struct io_Reader__2337 t12;
+ struct io_Reader__2337 t15;
+ struct io_Reader__2337 const *t13;
+ nav__4226_38 t14;
+ nav__4226_38 t18;
  uint8_t const (*t21)[8];
  uint64_t t22;
- nav__4213_64 t16;
+ nav__4226_64 t16;
  uint16_t t17;
  uint8_t t19[8];
  uint8_t t20[8];
  t0 = a0;
- t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t0;
+ t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t0;
  t2 = (*t1);
  t3 = t2;
- t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *)&t3;
+ t1 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *)&t3;
  t4 = t1;
- t5 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const *const *)&t4;
+ t5 = (struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const *const *)&t4;
  t7 = (void const **)&t6.context;
  t1 = (*t5);
- t8 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t1->context;
+ t8 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t1->context;
  t9 = (void const *)t8;
  (*t7) = t9;
- t10 = (nav__4213_50 (**)(void const *, nav__4213_52))&t6.readFn;
- (*t10) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4156;
+ t10 = (nav__4226_50 (**)(void const *, nav__4226_52))&t6.readFn;
+ (*t10) = &io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4169;
  t11 = t6;
  t12 = t11;
- t13 = (struct io_Reader__2307 const *)&t12;
+ t13 = (struct io_Reader__2337 const *)&t12;
  t11 = (*t13);
  t15 = t11;
- t13 = (struct io_Reader__2307 const *)&t15;
+ t13 = (struct io_Reader__2337 const *)&t15;
  t11 = (*t13);
- t16 = io_Reader_readBytesNoEof__anon_2431__4203(t11);
+ t16 = io_Reader_readBytesNoEof__anon_2461__4216(t11);
  if (t16.error) {
   t17 = t16.error;
   t18.payload = UINT64_C(0xaaaaaaaaaaaaaaaa);
@@ -1957,7 +1992,7 @@ static nav__4213_38 bincode_deserializeInt__anon_2657__4213(struct io_GenericRea
  goto zig_block_0;
 
  zig_block_0:;
- memcpy(&t18, &t14, sizeof(nav__4213_38));
+ memcpy(&t18, &t14, sizeof(nav__4226_38));
  if (t18.error) {
   t17 = t18.error;
   t18.payload = UINT64_C(0xaaaaaaaaaaaaaaaa);
@@ -1970,12 +2005,12 @@ static nav__4213_38 bincode_deserializeInt__anon_2657__4213(struct io_GenericRea
  return t18;
 }
 
-static nav__4212_38 bincode_deserializeAlloc__anon_2652__4212(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4212_38 t0;
+static nav__4225_38 bincode_deserializeAlloc__anon_2682__4225(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4225_38 t0;
  uint64_t t2;
  uint16_t t1;
  (void)a1;
- t0 = bincode_deserializeInt__anon_2657__4213(a0);
+ t0 = bincode_deserializeInt__anon_2687__4226(a0);
  if (t0.error) {
   t1 = t0.error;
   t0.payload = UINT64_C(0xaaaaaaaaaaaaaaaa);
@@ -1988,20 +2023,20 @@ static nav__4212_38 bincode_deserializeAlloc__anon_2652__4212(struct io_GenericR
  return t0;
 }
 
-static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4211_39 t2;
- nav__4211_56 t6;
+static nav__4224_39 bincode_deserializeUnionAlloc__anon_2669__4224(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4224_39 t2;
+ nav__4224_56 t6;
  uint64_t t7;
- struct shared_MarkerType__1942 t8;
- nav__4211_54 t0;
+ struct shared_MarkerType__1953 t8;
+ nav__4224_54 t0;
  uint32_t t3;
  uint16_t t1;
  uint8_t t4;
  bool t5;
- t0 = bincode_deserializeAlloc__anon_2281__4159(a0, a1);
+ t0 = bincode_deserializeAlloc__anon_2311__4172(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t2.payload = (struct shared_MarkerType__1942){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
+  t2.payload = (struct shared_MarkerType__1953){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
   t2.error = t1;
   return t2;
  }
@@ -2009,10 +2044,10 @@ static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_Gen
  t4 = (uint8_t)t3;
  t5 = t4 == UINT8_C(0);
  if (t5) {
-  t6 = bincode_deserializeAlloc__anon_2652__4212(a0, a1);
+  t6 = bincode_deserializeAlloc__anon_2682__4225(a0, a1);
   if (t6.error) {
    t1 = t6.error;
-   t2.payload = (struct shared_MarkerType__1942){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
+   t2.payload = (struct shared_MarkerType__1953){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
    t2.error = t1;
    return t2;
   }
@@ -2028,10 +2063,10 @@ static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_Gen
  zig_block_0:;
  t5 = t4 == UINT8_C(1);
  if (t5) {
-  t6 = bincode_deserializeAlloc__anon_2652__4212(a0, a1);
+  t6 = bincode_deserializeAlloc__anon_2682__4225(a0, a1);
   if (t6.error) {
    t1 = t6.error;
-   t2.payload = (struct shared_MarkerType__1942){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
+   t2.payload = (struct shared_MarkerType__1953){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
    t2.error = t1;
    return t2;
   }
@@ -2047,10 +2082,10 @@ static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_Gen
  zig_block_1:;
  t5 = t4 == UINT8_C(2);
  if (t5) {
-  t6 = bincode_deserializeAlloc__anon_2652__4212(a0, a1);
+  t6 = bincode_deserializeAlloc__anon_2682__4225(a0, a1);
   if (t6.error) {
    t1 = t6.error;
-   t2.payload = (struct shared_MarkerType__1942){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
+   t2.payload = (struct shared_MarkerType__1953){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
    t2.error = t1;
    return t2;
   }
@@ -2066,10 +2101,10 @@ static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_Gen
  zig_block_2:;
  t5 = t4 == UINT8_C(3);
  if (t5) {
-  t6 = bincode_deserializeAlloc__anon_2652__4212(a0, a1);
+  t6 = bincode_deserializeAlloc__anon_2682__4225(a0, a1);
   if (t6.error) {
    t1 = t6.error;
-   t2.payload = (struct shared_MarkerType__1942){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
+   t2.payload = (struct shared_MarkerType__1953){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
    t2.error = t1;
    return t2;
   }
@@ -2086,14 +2121,14 @@ static nav__4211_39 bincode_deserializeUnionAlloc__anon_2639__4211(struct io_Gen
  zig_unreachable();
 }
 
-static nav__4210_39 bincode_deserializeAlloc__anon_2605__4210(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4210_39 t0;
- struct shared_MarkerType__1942 t2;
+static nav__4223_39 bincode_deserializeAlloc__anon_2635__4223(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4223_39 t0;
+ struct shared_MarkerType__1953 t2;
  uint16_t t1;
- t0 = bincode_deserializeUnionAlloc__anon_2639__4211(a0, a1);
+ t0 = bincode_deserializeUnionAlloc__anon_2669__4224(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t0.payload = (struct shared_MarkerType__1942){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
+  t0.payload = (struct shared_MarkerType__1953){{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)};
   t0.error = t1;
   return t0;
  }
@@ -2103,32 +2138,32 @@ static nav__4210_39 bincode_deserializeAlloc__anon_2605__4210(struct io_GenericR
  return t0;
 }
 
-static nav__4209_39 bincode_deserializeStructAlloc__anon_2587__4209(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
+static nav__4222_39 bincode_deserializeStructAlloc__anon_2617__4222(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
  uint32_t *t1;
- nav__4209_39 t4;
- struct shared_MarkerType__1942 *t6;
- nav__4209_60 t7;
- struct shared_MarkerType__1942 t8;
- struct shared_Command__struct_1940__1940 t9;
- struct shared_Command__struct_1940__1940 t0;
- nav__4209_57 t2;
+ nav__4222_39 t4;
+ struct shared_MarkerType__1953 *t6;
+ nav__4222_60 t7;
+ struct shared_MarkerType__1953 t8;
+ struct shared_Command__struct_1951__1951 t9;
+ struct shared_Command__struct_1951__1951 t0;
+ nav__4222_57 t2;
  uint32_t t5;
  uint16_t t3;
  t1 = (uint32_t *)&t0.pid;
- t2 = bincode_deserializeAlloc__anon_2281__4159(a0, a1);
+ t2 = bincode_deserializeAlloc__anon_2311__4172(a0, a1);
  if (t2.error) {
   t3 = t2.error;
-  t4.payload = (struct shared_Command__struct_1940__1940){{{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)},UINT32_C(0xaaaaaaaa)};
+  t4.payload = (struct shared_Command__struct_1951__1951){{{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)},UINT32_C(0xaaaaaaaa)};
   t4.error = t3;
   return t4;
  }
  t5 = t2.payload;
  (*t1) = t5;
- t6 = (struct shared_MarkerType__1942 *)&t0.marker;
- t7 = bincode_deserializeAlloc__anon_2605__4210(a0, a1);
+ t6 = (struct shared_MarkerType__1953 *)&t0.marker;
+ t7 = bincode_deserializeAlloc__anon_2635__4223(a0, a1);
  if (t7.error) {
   t3 = t7.error;
-  t4.payload = (struct shared_Command__struct_1940__1940){{{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)},UINT32_C(0xaaaaaaaa)};
+  t4.payload = (struct shared_Command__struct_1951__1951){{{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)},UINT32_C(0xaaaaaaaa)};
   t4.error = t3;
   return t4;
  }
@@ -2140,14 +2175,14 @@ static nav__4209_39 bincode_deserializeStructAlloc__anon_2587__4209(struct io_Ge
  return t4;
 }
 
-static nav__4208_39 bincode_deserializeAlloc__anon_2573__4208(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4208_39 t0;
- struct shared_Command__struct_1940__1940 t2;
+static nav__4221_39 bincode_deserializeAlloc__anon_2603__4221(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4221_39 t0;
+ struct shared_Command__struct_1951__1951 t2;
  uint16_t t1;
- t0 = bincode_deserializeStructAlloc__anon_2587__4209(a0, a1);
+ t0 = bincode_deserializeStructAlloc__anon_2617__4222(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t0.payload = (struct shared_Command__struct_1940__1940){{{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)},UINT32_C(0xaaaaaaaa)};
+  t0.payload = (struct shared_Command__struct_1951__1951){{{UINT64_C(0xaaaaaaaaaaaaaaaa)},UINT8_C(0x2)},UINT32_C(0xaaaaaaaa)};
   t0.error = t1;
   return t0;
  }
@@ -2157,26 +2192,26 @@ static nav__4208_39 bincode_deserializeAlloc__anon_2573__4208(struct io_GenericR
  return t0;
 }
 
-static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4158_39 t2;
- nav__4158_68 t6;
- struct shared_Command__struct_1938__1938 t7;
- struct shared_Command__1935 t8;
- nav__4158_70 t9;
- struct shared_Command__struct_1939__1939 t10;
- nav__4158_72 t11;
- struct shared_Command__struct_1940__1940 t12;
- nav__4158_74 t13;
+static nav__4171_39 bincode_deserializeUnionAlloc__anon_2306__4171(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4171_39 t2;
+ nav__4171_68 t6;
+ struct shared_Command__struct_1949__1949 t7;
+ struct shared_Command__1946 t8;
+ nav__4171_70 t9;
+ struct shared_Command__struct_1950__1950 t10;
+ nav__4171_72 t11;
+ struct shared_Command__struct_1951__1951 t12;
+ nav__4171_74 t13;
  uint64_t t14;
- nav__4158_66 t0;
+ nav__4171_66 t0;
  uint32_t t3;
  uint16_t t1;
  uint8_t t4;
  bool t5;
- t0 = bincode_deserializeAlloc__anon_2281__4159(a0, a1);
+ t0 = bincode_deserializeAlloc__anon_2311__4172(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t2.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+  t2.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
   t2.error = t1;
   return t2;
  }
@@ -2184,10 +2219,10 @@ static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_Gen
  t4 = (uint8_t)t3;
  t5 = t4 == UINT8_C(0);
  if (t5) {
-  t6 = bincode_deserializeAlloc__anon_2351__4199(a0, a1);
+  t6 = bincode_deserializeAlloc__anon_2381__4212(a0, a1);
   if (t6.error) {
    t1 = t6.error;
-   t2.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t2.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
    t2.error = t1;
    return t2;
   }
@@ -2203,42 +2238,42 @@ static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_Gen
  zig_block_0:;
  t5 = t4 == UINT8_C(1);
  if (t5) {
-  (void)bincode_deserializeAlloc__anon_2470__4205(a0, a1);
-  return (nav__4158_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(1)},0};
+  (void)bincode_deserializeAlloc__anon_2500__4218(a0, a1);
+  return (nav__4171_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(1)},0};
  }
  goto zig_block_1;
 
  zig_block_1:;
  t5 = t4 == UINT8_C(2);
  if (t5) {
-  (void)bincode_deserializeAlloc__anon_2470__4205(a0, a1);
-  return (nav__4158_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(2)},0};
+  (void)bincode_deserializeAlloc__anon_2500__4218(a0, a1);
+  return (nav__4171_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(2)},0};
  }
  goto zig_block_2;
 
  zig_block_2:;
  t5 = t4 == UINT8_C(3);
  if (t5) {
-  (void)bincode_deserializeAlloc__anon_2470__4205(a0, a1);
-  return (nav__4158_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(3)},0};
+  (void)bincode_deserializeAlloc__anon_2500__4218(a0, a1);
+  return (nav__4171_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(3)},0};
  }
  goto zig_block_3;
 
  zig_block_3:;
  t5 = t4 == UINT8_C(4);
  if (t5) {
-  (void)bincode_deserializeAlloc__anon_2470__4205(a0, a1);
-  return (nav__4158_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(4)},0};
+  (void)bincode_deserializeAlloc__anon_2500__4218(a0, a1);
+  return (nav__4171_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(4)},0};
  }
  goto zig_block_4;
 
  zig_block_4:;
  t5 = t4 == UINT8_C(5);
  if (t5) {
-  t9 = bincode_deserializeAlloc__anon_2515__4206(a0, a1);
+  t9 = bincode_deserializeAlloc__anon_2545__4219(a0, a1);
   if (t9.error) {
    t1 = t9.error;
-   t2.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t2.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
    t2.error = t1;
    return t2;
   }
@@ -2254,18 +2289,18 @@ static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_Gen
  zig_block_5:;
  t5 = t4 == UINT8_C(6);
  if (t5) {
-  (void)bincode_deserializeAlloc__anon_2470__4205(a0, a1);
-  return (nav__4158_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(6)},0};
+  (void)bincode_deserializeAlloc__anon_2500__4218(a0, a1);
+  return (nav__4171_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(6)},0};
  }
  goto zig_block_6;
 
  zig_block_6:;
  t5 = t4 == UINT8_C(7);
  if (t5) {
-  t11 = bincode_deserializeAlloc__anon_2573__4208(a0, a1);
+  t11 = bincode_deserializeAlloc__anon_2603__4221(a0, a1);
   if (t11.error) {
    t1 = t11.error;
-   t2.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t2.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
    t2.error = t1;
    return t2;
   }
@@ -2281,10 +2316,10 @@ static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_Gen
  zig_block_7:;
  t5 = t4 == UINT8_C(8);
  if (t5) {
-  t13 = bincode_deserializeAlloc__anon_2652__4212(a0, a1);
+  t13 = bincode_deserializeAlloc__anon_2682__4225(a0, a1);
   if (t13.error) {
    t1 = t13.error;
-   t2.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t2.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
    t2.error = t1;
    return t2;
   }
@@ -2301,14 +2336,14 @@ static nav__4158_39 bincode_deserializeUnionAlloc__anon_2276__4158(struct io_Gen
  zig_unreachable();
 }
 
-static nav__4157_39 bincode_deserializeAlloc__anon_2179__4157(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 const a0, struct mem_Allocator__565 const a1) {
- nav__4157_39 t0;
- struct shared_Command__1935 t2;
+static nav__4170_39 bincode_deserializeAlloc__anon_2209__4170(struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 const a0, struct mem_Allocator__565 const a1) {
+ nav__4170_39 t0;
+ struct shared_Command__1946 t2;
  uint16_t t1;
- t0 = bincode_deserializeUnionAlloc__anon_2276__4158(a0, a1);
+ t0 = bincode_deserializeUnionAlloc__anon_2306__4171(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t0.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+  t0.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
   t0.error = t1;
   return t0;
  }
@@ -2318,118 +2353,178 @@ static nav__4157_39 bincode_deserializeAlloc__anon_2179__4157(struct io_GenericR
  return t0;
 }
 
-static nav__1082_39 fifo_UnixPipe_Reader_recvCmd__1082(struct fifo_UnixPipe_Reader__602 *const a0) {
+static nav__1085_39 fifo_UnixPipe_Reader_recvCmd__1085(struct fifo_UnixPipe_Reader__602 *const a0) {
  struct fifo_UnixPipe_Reader__602 *const *t1;
- struct fifo_UnixPipe_Reader__602 *t3;
+ uintptr_t t3;
+ uintptr_t t10;
+ struct fifo_UnixPipe_Reader__602 *t4;
  struct fifo_UnixPipe_Reader__602 *t0;
- struct fs_File__608 *t4;
- nav__1082_71 t6;
- nav__1082_74 t7;
- nav__1082_39 t9;
- uint8_t const (*t10)[4];
- struct mem_Allocator__565 *t13;
- struct mem_Allocator__565 t14;
- uintptr_t t15;
- nav__1082_78 t16;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 t19;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 t18;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t20;
- struct shared_Command__1935 t21;
- struct fs_File__608 t5;
- uint32_t t12;
- uint16_t t8;
- uint8_t t11[4];
+ struct fs_File__608 *t5;
+ nav__1085_71 t7;
+ nav__1085_74 t8;
+ nav__1085_39 t12;
+ nav__1085_39 t13;
+ uint64_t t14;
+ uint64_t t21;
+ uint8_t const (*t15)[4];
+ struct mem_Allocator__565 *t18;
+ struct mem_Allocator__565 t19;
+ nav__1085_78 t20;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 t23;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 t22;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t24;
+ struct shared_Command__1946 t25;
+ struct fs_File__608 t6;
+ uint32_t t17;
+ uint16_t t11;
+ bool t9;
+ uint8_t t16[4];
  uint8_t t2[4];
- bool t17;
  t0 = a0;
  t1 = (struct fifo_UnixPipe_Reader__602 *const *)&t0;
- t3 = (*t1);
- t4 = (struct fs_File__608 *)&t3->file;
- t5 = (*t4);
- t6.ptr = &t2[(uintptr_t)0ul];
- t6.len = (uintptr_t)4ul;
- t7 = fs_File_readAll__1220(t5, t6);
- if (t7.error) {
-  t8 = t7.error;
-  t9.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
-  t9.error = t8;
-  return t9;
+ t4 = (*t1);
+ t5 = (struct fs_File__608 *)&t4->file;
+ t6 = (*t5);
+ t7.ptr = &t2[(uintptr_t)0ul];
+ t7.len = (uintptr_t)4ul;
+ t8 = fs_File_readAll__1223(t6, t7);
+ t9 = t8.error == UINT16_C(0);
+ if (t9) {
+  t10 = t8.payload;
+  t3 = t10;
+  goto zig_block_0;
  }
- t10 = (uint8_t const (*)[4])&t2;
- memcpy(t11, (const char *)t10, sizeof(uint8_t[4]));
- memcpy(&t12, &t11, sizeof(uint32_t));
- t12 = zig_wrap_u32(t12, UINT8_C(32));
- t3 = (*t1);
- t13 = (struct mem_Allocator__565 *)&t3->allocator;
- t14 = (*t13);
- t15 = (uintptr_t)t12;
- t16 = mem_Allocator_alloc__anon_2129__4091(t14, t15);
- if (t16.error) {
-  t8 = t16.error;
-  t9.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
-  t9.error = t8;
-  return t9;
+ t11 = t8.error;
+ switch (t11) {
+  case zig_error_WouldBlock:
+  case zig_error_BrokenPipe: {
+   t12 = (nav__1085_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)},zig_error_NotReady};
+   goto zig_block_1;
+  }
+  default: {
+   t13.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t13.error = t11;
+   t12 = t13;
+   goto zig_block_1;
+  }
  }
- t6 = t16.payload;
- zig_loop_36:
- t3 = (*t1);
- t4 = (struct fs_File__608 *)&t3->file;
- t5 = (*t4);
- t7 = fs_File_readAll__1220(t5, t6);
- t17 = t7.error == UINT16_C(0);
- if (t17) {
-  goto zig_block_2;
- }
- goto zig_block_1;
-
- zig_block_2:;
- goto zig_block_0;
 
  zig_block_1:;
- goto zig_loop_36;
+ return t12;
 
  zig_block_0:;
- t19 = io_fixed_buffer_stream_fixedBufferStream__anon_2151__4123(t6);
- t18 = t19;
- t20 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_reader__4112(&t18);
- t13 = (struct mem_Allocator__565 *)&a0->allocator;
- t14 = (*t13);
- t9 = bincode_deserializeAlloc__anon_2179__4157(t20, t14);
- if (t9.error) {
-  t8 = t9.error;
-  t3 = (*t1);
-  t13 = (struct mem_Allocator__565 *)&t3->allocator;
-  t14 = (*t13);
-  mem_Allocator_free__anon_2698__4214(t14, t6);
-  t9.payload = (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
-  t9.error = t8;
-  return t9;
+ t14 = t3;
+ t9 = t14 < UINT64_C(4);
+ if (t9) {
+  return (nav__1085_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)},zig_error_UnexpectedEof};
  }
- t21 = t9.payload;
- t3 = (*t1);
- t13 = (struct mem_Allocator__565 *)&t3->allocator;
- t14 = (*t13);
- mem_Allocator_free__anon_2698__4214(t14, t6);
- t9.payload = t21;
- t9.error = UINT16_C(0);
- return t9;
+ goto zig_block_2;
+
+ zig_block_2:;
+ t15 = (uint8_t const (*)[4])&t2;
+ memcpy(t16, (const char *)t15, sizeof(uint8_t[4]));
+ memcpy(&t17, &t16, sizeof(uint32_t));
+ t17 = zig_wrap_u32(t17, UINT8_C(32));
+ t4 = (*t1);
+ t18 = (struct mem_Allocator__565 *)&t4->allocator;
+ t19 = (*t18);
+ t3 = (uintptr_t)t17;
+ t20 = mem_Allocator_alloc__anon_2153__4103(t19, t3);
+ if (t20.error) {
+  t11 = t20.error;
+  t13.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+  t13.error = t11;
+  return t13;
+ }
+ t7 = t20.payload;
+ t4 = (*t1);
+ t5 = (struct fs_File__608 *)&t4->file;
+ t6 = (*t5);
+ t8 = fs_File_readAll__1223(t6, t7);
+ t9 = t8.error == UINT16_C(0);
+ if (t9) {
+  t10 = t8.payload;
+  t3 = t10;
+  goto zig_block_3;
+ }
+ t11 = t8.error;
+ switch (t11) {
+  case zig_error_WouldBlock:
+  case zig_error_BrokenPipe: {
+   t13 = (nav__1085_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)},zig_error_NotReady};
+   goto zig_block_4;
+  }
+  default: {
+   t12.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t12.error = t11;
+   t13 = t12;
+   goto zig_block_4;
+  }
+ }
+
+ zig_block_4:;
+ t4 = (*t1);
+ t18 = (struct mem_Allocator__565 *)&t4->allocator;
+ t19 = (*t18);
+ mem_Allocator_free__anon_2159__4104(t19, t7);
+ return t13;
+
+ zig_block_3:;
+ t14 = t3;
+ t21 = (uint64_t)t17;
+ t9 = t14 < t21;
+ if (t9) {
+  t4 = (*t1);
+  t18 = (struct mem_Allocator__565 *)&t4->allocator;
+  t19 = (*t18);
+  mem_Allocator_free__anon_2159__4104(t19, t7);
+  return (nav__1085_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)},zig_error_UnexpectedEof};
+ }
+ goto zig_block_5;
+
+ zig_block_5:;
+ t23 = io_fixed_buffer_stream_fixedBufferStream__anon_2181__4136(t7);
+ t22 = t23;
+ t24 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_reader__4125(&t22);
+ t18 = (struct mem_Allocator__565 *)&a0->allocator;
+ t19 = (*t18);
+ t13 = bincode_deserializeAlloc__anon_2209__4170(t24, t19);
+ if (t13.error) {
+  t11 = t13.error;
+  t4 = (*t1);
+  t18 = (struct mem_Allocator__565 *)&t4->allocator;
+  t19 = (*t18);
+  mem_Allocator_free__anon_2159__4104(t19, t7);
+  t13.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+  t13.error = t11;
+  return t13;
+ }
+ t25 = t13.payload;
+ t4 = (*t1);
+ t18 = (struct mem_Allocator__565 *)&t4->allocator;
+ t19 = (*t18);
+ mem_Allocator_free__anon_2159__4104(t19, t7);
+ t13.payload = t25;
+ t13.error = UINT16_C(0);
+ return t13;
 }
 
-static nav__1083_39 fifo_UnixPipe_Reader_waitForResponse__1083(struct fifo_UnixPipe_Reader__602 *const a0, nav__1083_42 const a1) {
+static nav__1086_39 fifo_UnixPipe_Reader_waitForResponse__1086(struct fifo_UnixPipe_Reader__602 *const a0, nav__1086_42 const a1) {
  zig_i128 t2;
  zig_i128 t6;
  struct fifo_UnixPipe_Reader__602 *const *t1;
  uint64_t t3;
  uint64_t t5;
- struct shared_Command__1935 t7;
- struct shared_Command__1935 t10;
+ struct shared_Command__1946 t7;
+ struct shared_Command__1946 t10;
  struct fifo_UnixPipe_Reader__602 *t8;
  struct fifo_UnixPipe_Reader__602 *t0;
- nav__1083_39 t9;
+ nav__1086_39 t9;
+ uint16_t t11;
  bool t4;
  t0 = a0;
  t1 = (struct fifo_UnixPipe_Reader__602 *const *)&t0;
- t2 = time_nanoTimestamp__4063();
+ t2 = time_nanoTimestamp__4075();
  t4 = a1.is_null != true;
  if (t4) {
   t5 = a1.payload;
@@ -2441,26 +2536,37 @@ static nav__1083_39 fifo_UnixPipe_Reader_waitForResponse__1083(struct fifo_UnixP
 
  zig_block_0:;
  zig_loop_13:
- t6 = time_nanoTimestamp__4063();
+ t6 = time_nanoTimestamp__4075();
  t6 = zig_sub_i128(t6, t2);
  t5 = zig_lo_i128(t6);
  t4 = t5 > t3;
  if (t4) {
-  return (nav__1083_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)},zig_error_AckTimeout};
+  return (nav__1086_39){{{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)},zig_error_AckTimeout};
  }
  goto zig_block_2;
 
  zig_block_2:;
  t8 = (*t1);
- t9 = fifo_UnixPipe_Reader_recvCmd__1082(t8);
+ t9 = fifo_UnixPipe_Reader_recvCmd__1085(t8);
  t4 = t9.error == UINT16_C(0);
  if (t4) {
   t10 = t9.payload;
   t7 = t10;
   goto zig_block_3;
  }
- utils_sleep__4219(UINT64_C(10000000));
- goto zig_block_1;
+ t11 = t9.error;
+ switch (t11) {
+  case zig_error_NotReady:
+  case zig_error_UnexpectedEof: {
+   utils_sleep__3832(UINT64_C(10000000));
+   goto zig_block_1;
+  }
+  default: {
+   t9.payload = (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(0xa)};
+   t9.error = t11;
+   return t9;
+  }
+ }
 
  zig_block_3:;
  t9.payload = t7;
@@ -2471,14 +2577,14 @@ static nav__1083_39 fifo_UnixPipe_Reader_waitForResponse__1083(struct fifo_UnixP
  goto zig_loop_13;
 }
 
-static uint16_t fifo_UnixPipe_Reader_waitForAck__1084(struct fifo_UnixPipe_Reader__602 *const a0, nav__1084_40 const a1) {
+static uint16_t fifo_UnixPipe_Reader_waitForAck__1087(struct fifo_UnixPipe_Reader__602 *const a0, nav__1087_40 const a1) {
  struct fifo_UnixPipe_Reader__602 *const *t1;
  struct fifo_UnixPipe_Reader__602 *t2;
  struct fifo_UnixPipe_Reader__602 *t0;
- nav__1084_60 t3;
- struct shared_Command__1935 t5;
- struct shared_Command__1935 t6;
- struct shared_Command__1935 const *t7;
+ nav__1087_60 t3;
+ struct shared_Command__1946 t5;
+ struct shared_Command__1946 t6;
+ struct shared_Command__1946 const *t7;
  struct mem_Allocator__565 *t10;
  struct mem_Allocator__565 t11;
  uint16_t t4;
@@ -2487,21 +2593,21 @@ static uint16_t fifo_UnixPipe_Reader_waitForAck__1084(struct fifo_UnixPipe_Reade
  t0 = a0;
  t1 = (struct fifo_UnixPipe_Reader__602 *const *)&t0;
  t2 = (*t1);
- t3 = fifo_UnixPipe_Reader_waitForResponse__1083(t2, a1);
+ t3 = fifo_UnixPipe_Reader_waitForResponse__1086(t2, a1);
  if (t3.error) {
   t4 = t3.error;
   return t4;
  }
  t5 = t3.payload;
  t6 = t5;
- t7 = (struct shared_Command__1935 const *)&t6;
+ t7 = (struct shared_Command__1946 const *)&t6;
  t8 = t5.tag;
  t9 = t8 == UINT8_C(3);
  if (t9) {
   t5 = (*t7);
   t10 = (struct mem_Allocator__565 *)&a0->allocator;
   t11 = (*t10);
-  shared_Command_deinit__3824(t5, t11);
+  shared_Command_deinit__3836(t5, t11);
   return 0;
  }
  t8 = t5.tag;
@@ -2510,22 +2616,22 @@ static uint16_t fifo_UnixPipe_Reader_waitForAck__1084(struct fifo_UnixPipe_Reade
   t5 = (*t7);
   t10 = (struct mem_Allocator__565 *)&a0->allocator;
   t11 = (*t10);
-  shared_Command_deinit__3824(t5, t11);
+  shared_Command_deinit__3836(t5, t11);
   return zig_error_UnexpectedError;
  }
  t5 = (*t7);
  t10 = (struct mem_Allocator__565 *)&a0->allocator;
  t11 = (*t10);
- shared_Command_deinit__3824(t5, t11);
+ shared_Command_deinit__3836(t5, t11);
  return zig_error_UnexpectedResponse;
 }
 
-static uint16_t instruments_perf_PerfInstrument_send_version__759(struct instruments_perf_PerfInstrument__559 *const a0, uint64_t const a1) {
+static uint16_t instruments_perf_PerfInstrument_send_version__760(struct instruments_perf_PerfInstrument__559 *const a0, uint64_t const a1) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
  struct fifo_UnixPipe_Writer__600 *t3;
- struct shared_Command__1935 t4;
+ struct shared_Command__1946 t4;
  struct fifo_UnixPipe_Reader__602 *t6;
  uint16_t t5;
  t0 = a0;
@@ -2534,32 +2640,33 @@ static uint16_t instruments_perf_PerfInstrument_send_version__759(struct instrum
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
  t4.tag = UINT8_C(8);
  t4.payload.SetVersion = a1;
- t5 = fifo_UnixPipe_Writer_sendCmd__1077(t3, t4);
+ t5 = fifo_UnixPipe_Writer_sendCmd__1080(t3, t4);
  if (t5) {
   return t5;
  }
  t2 = (*t1);
  t6 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t5 = fifo_UnixPipe_Reader_waitForAck__1084(t6, (nav__759_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t5 = fifo_UnixPipe_Reader_waitForAck__1087(t6, (nav__760_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t5) {
   return t5;
  }
  return 0;
 }
 
-struct instruments_root_InstrumentHooks__547 *c_instrument_hooks_init__238(void) {
+struct instruments_root_InstrumentHooks__547 *c_instrument_hooks_init__239(void) {
  struct instruments_root_InstrumentHooks__547 *t0;
  struct instruments_root_InstrumentHooks__547 *t3;
  struct instruments_root_InstrumentHooks__547 *t4;
- nav__238_46 t1;
+ struct instruments_root_InstrumentHooks__547 *t11;
+ nav__239_46 t1;
  struct instruments_root_InstrumentHooks__547 *const *t5;
- nav__238_72 t6;
+ nav__239_72 t6;
  struct instruments_root_InstrumentHooks__547 t7;
  struct instruments_perf_PerfInstrument__559 *t9;
  uint16_t t10;
  bool t2;
  uint8_t t8;
- t1 = mem_Allocator_create__anon_858__3574((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3562)});
+ t1 = mem_Allocator_create__anon_858__3577((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3565)});
  t2 = t1.error == UINT16_C(0);
  if (t2) {
   t3 = t1.payload;
@@ -2571,7 +2678,7 @@ struct instruments_root_InstrumentHooks__547 *c_instrument_hooks_init__238(void)
  zig_block_0:;
  t4 = t0;
  t5 = (struct instruments_root_InstrumentHooks__547 *const *)&t4;
- t6 = instruments_root_InstrumentHooks_init__725((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3562)});
+ t6 = instruments_root_InstrumentHooks_init__726((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3565)});
  t7 = t6.payload;
  (*t0) = t7;
  t7 = (*t0);
@@ -2580,12 +2687,38 @@ struct instruments_root_InstrumentHooks__547 *c_instrument_hooks_init__238(void)
  if (t2) {
   t3 = (*t5);
   t9 = (struct instruments_perf_PerfInstrument__559 *)&t3->payload.perf;
-  t10 = instruments_perf_PerfInstrument_send_version__759(t9, UINT64_C(1));
+  t10 = instruments_perf_PerfInstrument_send_version__760(t9, UINT64_C(1));
   t2 = t10 == UINT16_C(0);
   if (t2) {
    goto zig_block_2;
   }
-  goto zig_block_2;
+  (void)printf((char const *)&__anon_2757);
+  (void)printf((char const *)&__anon_2761);
+  t3 = (*t5);
+  t11 = t3;
+  t5 = (struct instruments_root_InstrumentHooks__547 *const *)&t11;
+  t7 = (*t3);
+  t8 = t7.tag;
+  switch (t8) {
+   case UINT8_C(0): {
+    goto zig_block_3;
+   }
+   case UINT8_C(1): {
+    t3 = (*t5);
+    t9 = (struct instruments_perf_PerfInstrument__559 *)&t3->payload.perf;
+    instruments_perf_PerfInstrument_deinit__752(t9);
+    goto zig_block_3;
+   }
+   case UINT8_C(2): {
+    goto zig_block_3;
+   }
+   default: zig_unreachable();
+  }
+
+  zig_block_3:;
+  mem_Allocator_destroy__anon_2777__4228((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3565)}, t0);
+  posix_exit__1442(UINT8_C(1));
+  zig_unreachable();
 
   zig_block_2:;
   goto zig_block_1;
@@ -2597,13 +2730,13 @@ struct instruments_root_InstrumentHooks__547 *c_instrument_hooks_init__238(void)
  return t3;
 }
 
-static nav__3574_40 mem_Allocator_create__anon_858__3574(struct mem_Allocator__565 const a0) {
+static nav__3577_40 mem_Allocator_create__anon_858__3577(struct mem_Allocator__565 const a0) {
  struct mem_Allocator__565 const *t1;
  struct mem_Allocator__565 t2;
  struct mem_Allocator__565 t0;
  uintptr_t t3;
- nav__3574_51 t4;
- nav__3574_40 t6;
+ nav__3577_51 t4;
+ nav__3577_40 t6;
  uint8_t *t7;
  struct instruments_root_InstrumentHooks__547 *t8;
  uint16_t t5;
@@ -2611,7 +2744,7 @@ static nav__3574_40 mem_Allocator_create__anon_858__3574(struct mem_Allocator__5
  t1 = (struct mem_Allocator__565 const *)&t0;
  t2 = (*t1);
  t3 = (uintptr_t)zig_return_address();
- t4 = mem_Allocator_allocBytesWithAlignment__anon_2736__4222(t2, (uintptr_t)72ul, t3);
+ t4 = mem_Allocator_allocBytesWithAlignment__anon_2793__4229(t2, (uintptr_t)72ul, t3);
  if (t4.error) {
   t5 = t4.error;
   t6.payload = ((struct instruments_root_InstrumentHooks__547 *)(uintptr_t)0xaaaaaaaaaaaaaaaaul);
@@ -2625,48 +2758,59 @@ static nav__3574_40 mem_Allocator_create__anon_858__3574(struct mem_Allocator__5
  return t6;
 }
 
-static struct instruments_valgrind_ValgrindInstrument__554 instruments_valgrind_ValgrindInstrument_init__738(struct mem_Allocator__565 const a0) {
+static struct instruments_valgrind_ValgrindInstrument__554 instruments_valgrind_ValgrindInstrument_init__739(struct mem_Allocator__565 const a0) {
  struct instruments_valgrind_ValgrindInstrument__554 t0;
  t0.allocator = a0;
  return t0;
 }
 
-static uint16_t fs_accessAbsolute__1139(nav__1139_39 const a0, struct fs_File_OpenFlags__1852 const a1) {
- struct fs_Dir__1854 const *t3;
- struct fs_Dir__1854 t1;
- struct fs_Dir__1854 t2;
+static uint16_t fs_accessAbsolute__1142(nav__1142_39 const a0, struct fs_File_OpenFlags__1858 const a1) {
+ struct fs_Dir__1860 const *t3;
+ struct fs_Dir__1860 t1;
+ struct fs_Dir__1860 t2;
  uint16_t t4;
  bool t0;
- t0 = fs_path_isAbsolute__4257(a0);
+ t0 = fs_path_isAbsolute__4264(a0);
  debug_assert__180(t0);
- t1 = fs_cwd__1131();
+ t1 = fs_cwd__1134();
  t2 = t1;
- t3 = (struct fs_Dir__1854 const *)&t2;
+ t3 = (struct fs_Dir__1860 const *)&t2;
  t1 = (*t3);
- t4 = fs_Dir_access__3780(t1, a0, a1);
+ t4 = fs_Dir_access__3783(t1, a0, a1);
  if (t4) {
   return t4;
  }
  return 0;
 }
 
-static nav__1136_39 fs_openFileAbsolute__1136(nav__1136_41 const a0, struct fs_File_OpenFlags__1852 const a1) {
- struct fs_Dir__1854 const *t3;
- struct fs_Dir__1854 t1;
- struct fs_Dir__1854 t2;
- nav__1136_39 t4;
+static nav__1139_39 fs_openFileAbsolute__1139(nav__1139_41 const a0, struct fs_File_OpenFlags__1858 const a1) {
+ struct fs_Dir__1860 const *t3;
+ struct fs_Dir__1860 t1;
+ struct fs_Dir__1860 t2;
+ nav__1139_39 t4;
  bool t0;
- t0 = fs_path_isAbsolute__4257(a0);
+ t0 = fs_path_isAbsolute__4264(a0);
  debug_assert__180(t0);
- t1 = fs_cwd__1131();
+ t1 = fs_cwd__1134();
  t2 = t1;
- t3 = (struct fs_Dir__1854 const *)&t2;
+ t3 = (struct fs_Dir__1860 const *)&t2;
  t1 = (*t3);
- t4 = fs_Dir_openFile__3716(t1, a0, a1);
+ t4 = fs_Dir_openFile__3719(t1, a0, a1);
  return t4;
 }
 
-static struct fifo_UnixPipe_Writer__600 fifo_UnixPipe_Writer_init__1074(struct fs_File__608 const a0, struct mem_Allocator__565 const a1) {
+static void utils_setNonBlocking__3833(int32_t const a0) {
+ int t0;
+ int t1;
+ t0 = a0;
+ t0 = fcntl(t0, 3, 0);
+ t0 = t0 | 2048;
+ t1 = a0;
+ (void)fcntl(t1, 4, t0);
+ return;
+}
+
+static struct fifo_UnixPipe_Writer__600 fifo_UnixPipe_Writer_init__1077(struct fs_File__608 const a0, struct mem_Allocator__565 const a1) {
  struct fs_File__608 *t1;
  struct mem_Allocator__565 *t2;
  struct fifo_UnixPipe_Writer__600 t0;
@@ -2677,7 +2821,7 @@ static struct fifo_UnixPipe_Writer__600 fifo_UnixPipe_Writer_init__1074(struct f
  return t0;
 }
 
-static struct fifo_UnixPipe_Reader__602 fifo_UnixPipe_Reader_init__1079(struct fs_File__608 const a0, struct mem_Allocator__565 const a1) {
+static struct fifo_UnixPipe_Reader__602 fifo_UnixPipe_Reader_init__1082(struct fs_File__608 const a0, struct mem_Allocator__565 const a1) {
  struct fs_File__608 *t1;
  struct mem_Allocator__565 *t2;
  struct fifo_UnixPipe_Reader__602 t0;
@@ -2688,7 +2832,7 @@ static struct fifo_UnixPipe_Reader__602 fifo_UnixPipe_Reader_init__1079(struct f
  return t0;
 }
 
-static uint16_t instruments_perf_PerfInstrument_send_cmd__752(struct instruments_perf_PerfInstrument__559 *const a0, struct shared_Command__1935 const a1) {
+static uint16_t instruments_perf_PerfInstrument_send_cmd__753(struct instruments_perf_PerfInstrument__559 *const a0, struct shared_Command__1946 const a1) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
@@ -2699,20 +2843,20 @@ static uint16_t instruments_perf_PerfInstrument_send_cmd__752(struct instruments
  t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
  t2 = (*t1);
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
- t4 = fifo_UnixPipe_Writer_sendCmd__1077(t3, a1);
+ t4 = fifo_UnixPipe_Writer_sendCmd__1080(t3, a1);
  if (t4) {
   return t4;
  }
  t2 = (*t1);
  t5 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t4 = fifo_UnixPipe_Reader_waitForAck__1084(t5, (nav__752_72){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t4 = fifo_UnixPipe_Reader_waitForAck__1087(t5, (nav__753_72){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t4) {
   return t4;
  }
  return 0;
 }
 
-static bool instruments_perf_PerfInstrument_is_instrumented__753(struct instruments_perf_PerfInstrument__559 *const a0) {
+static bool instruments_perf_PerfInstrument_is_instrumented__754(struct instruments_perf_PerfInstrument__559 *const a0) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
@@ -2721,7 +2865,7 @@ static bool instruments_perf_PerfInstrument_is_instrumented__753(struct instrume
  t0 = a0;
  t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
  t2 = (*t1);
- t3 = instruments_perf_PerfInstrument_send_cmd__752(t2, (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(4)});
+ t3 = instruments_perf_PerfInstrument_send_cmd__753(t2, (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(4)});
  t4 = t3 == UINT16_C(0);
  if (t4) {
   goto zig_block_0;
@@ -2732,67 +2876,67 @@ static bool instruments_perf_PerfInstrument_is_instrumented__753(struct instrume
  return true;
 }
 
-static struct array_list_ArrayListAligned_28u8_2cnull_29__1963 array_list_ArrayListAligned_28u8_2cnull_29_init__3876(struct mem_Allocator__565 const a0) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t0;
- t0.items = (nav__3876_42){(uint8_t *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
+static struct array_list_ArrayListAligned_28u8_2cnull_29__1974 array_list_ArrayListAligned_28u8_2cnull_29_init__3888(struct mem_Allocator__565 const a0) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t0;
+ t0.items = (nav__3888_42){(uint8_t *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
  t0.capacity = (uintptr_t)0ul;
  t0.allocator = a0;
  return t0;
 }
 
-static struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 array_list_ArrayListAligned_28u8_2cnull_29_writer__3901(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 **t1;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 **)&t0.context;
+static struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 array_list_ArrayListAligned_28u8_2cnull_29_writer__3913(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 **t1;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 **)&t0.context;
  (*t1) = a0;
  return t0;
 }
 
-static uint16_t bincode_serialize__anon_2004__4049(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__1935 const a1) {
+static uint16_t bincode_serialize__anon_2015__4061(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__1946 const a1) {
  uint16_t t0;
- t0 = bincode_serializeUnion__anon_2781__4320(a0, a1);
+ t0 = bincode_serializeUnion__anon_2860__5247(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static void array_list_ArrayListAligned_28u8_2cnull_29_deinit__3878(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 const a0) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 const *t1;
+static void array_list_ArrayListAligned_28u8_2cnull_29_deinit__3890(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 const a0) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 const *t1;
  struct mem_Allocator__565 const *t2;
  struct mem_Allocator__565 t3;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t4;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t0;
- nav__3878_41 t5;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t4;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t0;
+ nav__3890_41 t5;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 const *)&t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 const *)&t0;
  t2 = (struct mem_Allocator__565 const *)&t1->allocator;
  t3 = (*t2);
  t4 = (*t1);
- t5 = array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3924(t4);
- mem_Allocator_free__anon_2698__4214(t3, t5);
+ t5 = array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3936(t4);
+ mem_Allocator_free__anon_2159__4104(t3, t5);
  return;
 }
 
-static uint8_t const (*mem_asBytes__anon_2046__4050(uint32_t const *const a0))[4] {
+static uint8_t const (*mem_asBytes__anon_2057__4062(uint32_t const *const a0))[4] {
  uint8_t const (*t0)[4];
  t0 = (uint8_t const (*)[4])a0;
  return t0;
 }
 
-static uint16_t fs_File_writeAll__1230(struct fs_File__608 const a0, nav__1230_40 const a1) {
+static uint16_t fs_File_writeAll__1233(struct fs_File__608 const a0, nav__1233_40 const a1) {
  struct fs_File__608 const *t1;
- nav__1230_40 const *t3;
+ nav__1233_40 const *t3;
  uintptr_t t5;
  uintptr_t t6;
  uintptr_t t13;
  uintptr_t t4;
  uint64_t t7;
  uint64_t t8;
- nav__1230_40 t11;
- nav__1230_40 t2;
+ nav__1233_40 t11;
+ nav__1233_40 t2;
  uint8_t const *t12;
- nav__1230_47 t14;
+ nav__1233_47 t14;
  struct fs_File__608 t10;
  struct fs_File__608 t0;
  uint16_t t15;
@@ -2800,7 +2944,7 @@ static uint16_t fs_File_writeAll__1230(struct fs_File__608 const a0, nav__1230_4
  t0 = a0;
  t1 = (struct fs_File__608 const *)&t0;
  t2 = a1;
- t3 = (nav__1230_40 const *)&t2;
+ t3 = (nav__1233_40 const *)&t2;
  t4 = (uintptr_t)0ul;
  zig_loop_11:
  t5 = t4;
@@ -2819,7 +2963,7 @@ static uint16_t fs_File_writeAll__1230(struct fs_File__608 const a0, nav__1230_4
   t5 = t13 - t5;
   t11.ptr = t12;
   t11.len = t5;
-  t14 = fs_File_write__1229(t10, t11);
+  t14 = fs_File_write__1232(t10, t11);
   if (t14.error) {
    t15 = t14.error;
    return t15;
@@ -2838,16 +2982,16 @@ static uint16_t fs_File_writeAll__1230(struct fs_File__608 const a0, nav__1230_4
  return 0;
 }
 
-static zig_i128 time_nanoTimestamp__4063(void) {
+static zig_i128 time_nanoTimestamp__4075(void) {
  zig_i128 t6;
  zig_i128 t7;
- nav__4063_41 t0;
- struct os_linux_timespec__struct_2843__2843 t2;
- struct os_linux_timespec__struct_2843__2843 t3;
+ nav__4075_41 t0;
+ struct os_linux_timespec__struct_2922__2922 t2;
+ struct os_linux_timespec__struct_2922__2922 t3;
  intptr_t t5;
  uint16_t t4;
  bool t1;
- t0 = posix_clock_gettime__1630(UINT32_C(0));
+ t0 = posix_clock_gettime__1633(UINT32_C(0));
  t1 = t0.error == UINT16_C(0);
  if (t1) {
   t3 = t0.payload;
@@ -2873,18 +3017,18 @@ static zig_i128 time_nanoTimestamp__4063(void) {
  return t7;
 }
 
-static nav__1220_38 fs_File_readAll__1220(struct fs_File__608 const a0, nav__1220_41 const a1) {
+static nav__1223_38 fs_File_readAll__1223(struct fs_File__608 const a0, nav__1223_41 const a1) {
  struct fs_File__608 const *t1;
- nav__1220_41 const *t3;
+ nav__1223_41 const *t3;
  uintptr_t t5;
  uintptr_t t6;
  uintptr_t t4;
  uint64_t t7;
  uint64_t t8;
- nav__1220_41 t11;
- nav__1220_41 t2;
+ nav__1223_41 t11;
+ nav__1223_41 t2;
  uint8_t *t12;
- nav__1220_38 t13;
+ nav__1223_38 t13;
  struct fs_File__608 t10;
  struct fs_File__608 t0;
  uint16_t t14;
@@ -2892,7 +3036,7 @@ static nav__1220_38 fs_File_readAll__1220(struct fs_File__608 const a0, nav__122
  t0 = a0;
  t1 = (struct fs_File__608 const *)&t0;
  t2 = a1;
- t3 = (nav__1220_41 const *)&t2;
+ t3 = (nav__1223_41 const *)&t2;
  t4 = (uintptr_t)0ul;
  zig_loop_11:
  t5 = t4;
@@ -2910,7 +3054,7 @@ static nav__1220_38 fs_File_readAll__1220(struct fs_File__608 const a0, nav__122
   t6 = t5 - t6;
   t11.ptr = t12;
   t11.len = t6;
-  t13 = fs_File_read__1219(t10, t11);
+  t13 = fs_File_read__1222(t10, t11);
   if (t13.error) {
    t14 = t13.error;
    t13.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
@@ -2943,19 +3087,19 @@ static nav__1220_38 fs_File_readAll__1220(struct fs_File__608 const a0, nav__122
  return t13;
 }
 
-static nav__4091_40 mem_Allocator_alloc__anon_2129__4091(struct mem_Allocator__565 const a0, uintptr_t const a1) {
+static nav__4103_40 mem_Allocator_alloc__anon_2153__4103(struct mem_Allocator__565 const a0, uintptr_t const a1) {
  struct mem_Allocator__565 const *t1;
  struct mem_Allocator__565 t2;
  struct mem_Allocator__565 t0;
  struct mem_Allocator__565 t5;
  uintptr_t t3;
- nav__4091_40 t4;
- nav__4091_40 t8;
- nav__4091_51 t6;
+ nav__4103_40 t4;
+ nav__4103_40 t8;
+ nav__4103_51 t6;
  uint8_t *t9;
  uint8_t *t10;
  uint8_t *const *t11;
- nav__4091_39 t12;
+ nav__4103_39 t12;
  uint16_t t7;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
@@ -2964,10 +3108,10 @@ static nav__4091_40 mem_Allocator_alloc__anon_2129__4091(struct mem_Allocator__5
  t5 = t2;
  t1 = (struct mem_Allocator__565 const *)&t5;
  t2 = (*t1);
- t6 = mem_Allocator_allocWithSizeAndAlignment__anon_2874__4321(t2, a1, t3);
+ t6 = mem_Allocator_allocWithSizeAndAlignment__anon_2953__5248(t2, a1, t3);
  if (t6.error) {
   t7 = t6.error;
-  t8.payload = (nav__4091_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t8.payload = (nav__4103_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t8.error = t7;
   t4 = t8;
   goto zig_block_0;
@@ -2988,105 +3132,9 @@ static nav__4091_40 mem_Allocator_alloc__anon_2129__4091(struct mem_Allocator__5
  return t4;
 }
 
-static struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 io_fixed_buffer_stream_fixedBufferStream__anon_2151__4123(nav__4123_40 const a0) {
- nav__4123_40 *t1;
- uintptr_t *t2;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 t0;
- t1 = (nav__4123_40 *)&t0.buffer;
- (*t1) = a0;
- t2 = (uintptr_t *)&t0.pos;
- (*t2) = (uintptr_t)0ul;
- return t0;
-}
-
-static struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_reader__4112(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const a0) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 **t1;
- struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2171 t0;
- t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 **)&t0.context;
- (*t1) = a0;
- return t0;
-}
-
-static nav__4156_38 io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4156(void const *const a0, nav__4156_41 const a1) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t0;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *t1;
- nav__4156_38 t2;
- nav__4156_38 t3;
- t0 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)a0;
- t1 = (*t0);
- t2 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read__4115(t1, a1);
- memcpy(&t3, &t2, sizeof(nav__4156_38));
- return t3;
-}
-
-static nav__4198_39 io_Reader_readBytesNoEof__anon_2338__4198(struct io_Reader__2307 const a0) {
- struct io_Reader__2307 const *t1;
- struct io_Reader__2307 t3;
- struct io_Reader__2307 t0;
- nav__4198_46 t4;
- uint16_t t5;
- nav__4198_39 t6;
- uint8_t t7[4];
- uint8_t t2[4];
- t0 = a0;
- t1 = (struct io_Reader__2307 const *)&t0;
- t3 = (*t1);
- t4.ptr = &t2[(uintptr_t)0ul];
- t4.len = (uintptr_t)4ul;
- t5 = io_Reader_readNoEof__4165(t3, t4);
- if (t5) {
-  memcpy(t6.payload, "\252\252\252\252", sizeof(uint8_t[4]));
-  t6.error = t5;
-  return t6;
- }
- memcpy(t7, (const char *)&t2, sizeof(uint8_t[4]));
- memcpy(t6.payload, t7, sizeof(uint8_t[4]));
- t6.error = UINT16_C(0);
- return t6;
-}
-
-static nav__4203_39 io_Reader_readBytesNoEof__anon_2431__4203(struct io_Reader__2307 const a0) {
- struct io_Reader__2307 const *t1;
- struct io_Reader__2307 t3;
- struct io_Reader__2307 t0;
- nav__4203_46 t4;
- uint16_t t5;
- nav__4203_39 t6;
- uint8_t t7[8];
- uint8_t t2[8];
- t0 = a0;
- t1 = (struct io_Reader__2307 const *)&t0;
- t3 = (*t1);
- t4.ptr = &t2[(uintptr_t)0ul];
- t4.len = (uintptr_t)8ul;
- t5 = io_Reader_readNoEof__4165(t3, t4);
- if (t5) {
-  memcpy(t6.payload, "\252\252\252\252\252\252\252\252", sizeof(uint8_t[8]));
-  t6.error = t5;
-  return t6;
- }
- memcpy(t7, (const char *)&t2, sizeof(uint8_t[8]));
- memcpy(t6.payload, t7, sizeof(uint8_t[8]));
- t6.error = UINT16_C(0);
- return t6;
-}
-
-static nav__4163_38 io_Reader_readAll__4163(struct io_Reader__2307 const a0, nav__4163_41 const a1) {
- uintptr_t t0;
- nav__4163_38 t1;
- t0 = a1.len;
- t1 = io_Reader_readAtLeast__4164(a0, a1, t0);
- return t1;
-}
-
-static zig_cold zig_noreturn void bincode_invalidProtocol__anon_2455__4204(void) {
- debug_no_panic_call__4323((nav__4204_40){(uint8_t const *)&__anon_2896,(uintptr_t)88ul}, (nav__4204_42){(uintptr_t)0xaaaaaaaaaaaaaaaaul,true});
- zig_unreachable();
-}
-
-static void mem_Allocator_free__anon_2698__4214(struct mem_Allocator__565 const a0, nav__4214_40 const a1) {
+static void mem_Allocator_free__anon_2159__4104(struct mem_Allocator__565 const a0, nav__4104_40 const a1) {
  struct mem_Allocator__565 const *t1;
- nav__4214_40 t2;
+ nav__4104_40 t2;
  uintptr_t t3;
  uint64_t t4;
  uint8_t *t6;
@@ -3098,14 +3146,14 @@ static void mem_Allocator_free__anon_2698__4214(struct mem_Allocator__565 const 
  struct mem_Allocator__565 t12;
  struct mem_Allocator_VTable__568 const *const *t13;
  struct mem_Allocator_VTable__568 const *t14;
- void (*const *t15)(void *, nav__4214_40, uint8_t, uintptr_t);
- void (*t16)(void *, nav__4214_40, uint8_t, uintptr_t);
+ void (*const *t15)(void *, nav__4104_40, uint8_t, uintptr_t);
+ void (*t16)(void *, nav__4104_40, uint8_t, uintptr_t);
  void *t17;
  bool t5;
  uint8_t t11;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
- t2 = mem_sliceAsBytes__anon_2993__4350(a1);
+ t2 = mem_sliceAsBytes__anon_2966__5249(a1);
  t3 = t2.len;
  t4 = t3;
  t5 = t4 == UINT64_C(0);
@@ -3128,38 +3176,134 @@ static void mem_Allocator_free__anon_2698__4214(struct mem_Allocator__565 const 
  t7 = (uint8_t *)(((uintptr_t)t7) + ((uintptr_t)0ul*sizeof(uint8_t)));
  t2.ptr = t7;
  t2.len = t3;
- t11 = mem_Alignment_fromByteUnits__1045((uintptr_t)1ul);
+ t11 = mem_Alignment_fromByteUnits__1046((uintptr_t)1ul);
  t3 = (uintptr_t)zig_return_address();
  t12 = t10;
  t1 = (struct mem_Allocator__565 const *)&t12;
  t13 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
  t14 = (*t13);
- t15 = (void (*const *)(void *, nav__4214_40, uint8_t, uintptr_t))&t14->free;
+ t15 = (void (*const *)(void *, nav__4104_40, uint8_t, uintptr_t))&t14->free;
  t16 = (*t15);
  t17 = t10.ptr;
  t16(t17, t2, t11, t3);
  return;
 }
 
-static void utils_sleep__4219(uint64_t const a0) {
+static struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 io_fixed_buffer_stream_fixedBufferStream__anon_2181__4136(nav__4136_40 const a0) {
+ nav__4136_40 *t1;
+ uintptr_t *t2;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 t0;
+ t1 = (nav__4136_40 *)&t0.buffer;
+ (*t1) = a0;
+ t2 = (uintptr_t *)&t0.pos;
+ (*t2) = (uintptr_t)0ul;
+ return t0;
+}
+
+static struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_reader__4125(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const a0) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 **t1;
+ struct io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29__2201 t0;
+ t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 **)&t0.context;
+ (*t1) = a0;
+ return t0;
+}
+
+static nav__4169_38 io_GenericReader_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7b_7d_2c_28function_20_27read_27_29_29_typeEras__4169(void const *const a0, nav__4169_41 const a1) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t0;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *t1;
+ nav__4169_38 t2;
+ nav__4169_38 t3;
+ t0 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)a0;
+ t1 = (*t0);
+ t2 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read__4128(t1, a1);
+ memcpy(&t3, &t2, sizeof(nav__4169_38));
+ return t3;
+}
+
+static nav__4211_39 io_Reader_readBytesNoEof__anon_2368__4211(struct io_Reader__2337 const a0) {
+ struct io_Reader__2337 const *t1;
+ struct io_Reader__2337 t3;
+ struct io_Reader__2337 t0;
+ nav__4211_46 t4;
+ uint16_t t5;
+ nav__4211_39 t6;
+ uint8_t t7[4];
+ uint8_t t2[4];
+ t0 = a0;
+ t1 = (struct io_Reader__2337 const *)&t0;
+ t3 = (*t1);
+ t4.ptr = &t2[(uintptr_t)0ul];
+ t4.len = (uintptr_t)4ul;
+ t5 = io_Reader_readNoEof__4178(t3, t4);
+ if (t5) {
+  memcpy(t6.payload, "\252\252\252\252", sizeof(uint8_t[4]));
+  t6.error = t5;
+  return t6;
+ }
+ memcpy(t7, (const char *)&t2, sizeof(uint8_t[4]));
+ memcpy(t6.payload, t7, sizeof(uint8_t[4]));
+ t6.error = UINT16_C(0);
+ return t6;
+}
+
+static nav__4216_39 io_Reader_readBytesNoEof__anon_2461__4216(struct io_Reader__2337 const a0) {
+ struct io_Reader__2337 const *t1;
+ struct io_Reader__2337 t3;
+ struct io_Reader__2337 t0;
+ nav__4216_46 t4;
+ uint16_t t5;
+ nav__4216_39 t6;
+ uint8_t t7[8];
+ uint8_t t2[8];
+ t0 = a0;
+ t1 = (struct io_Reader__2337 const *)&t0;
+ t3 = (*t1);
+ t4.ptr = &t2[(uintptr_t)0ul];
+ t4.len = (uintptr_t)8ul;
+ t5 = io_Reader_readNoEof__4178(t3, t4);
+ if (t5) {
+  memcpy(t6.payload, "\252\252\252\252\252\252\252\252", sizeof(uint8_t[8]));
+  t6.error = t5;
+  return t6;
+ }
+ memcpy(t7, (const char *)&t2, sizeof(uint8_t[8]));
+ memcpy(t6.payload, t7, sizeof(uint8_t[8]));
+ t6.error = UINT16_C(0);
+ return t6;
+}
+
+static nav__4176_38 io_Reader_readAll__4176(struct io_Reader__2337 const a0, nav__4176_41 const a1) {
+ uintptr_t t0;
+ nav__4176_38 t1;
+ t0 = a1.len;
+ t1 = io_Reader_readAtLeast__4177(a0, a1, t0);
+ return t1;
+}
+
+static zig_cold zig_noreturn void bincode_invalidProtocol__anon_2485__4217(void) {
+ debug_no_panic_call__5251((nav__4217_40){(uint8_t const *)&__anon_3003,(uintptr_t)88ul}, (nav__4217_42){(uintptr_t)0xaaaaaaaaaaaaaaaaul,true});
+ zig_unreachable();
+}
+
+static void utils_sleep__3832(uint64_t const a0) {
  uint64_t t0;
  uint64_t t1;
  long *t3;
  long t4;
  long t7;
- nav__4219_42 t5;
- struct cimport_struct_timespec__3022 const *t9;
- struct cimport_struct_timespec__3022 *t10;
- struct cimport_struct_timespec__3022 t13;
- struct cimport_struct_timespec__3022 t2;
- struct cimport_struct_timespec__3022 t8;
+ nav__3832_42 t5;
+ struct cimport_struct_timespec__3100 const *t9;
+ struct cimport_struct_timespec__3100 *t10;
+ struct cimport_struct_timespec__3100 t13;
+ struct cimport_struct_timespec__3100 t2;
+ struct cimport_struct_timespec__3100 t8;
  int t11;
  int32_t t12;
  bool t6;
  t0 = a0 / UINT64_C(1000000000);
  t1 = a0 % UINT64_C(1000000000);
  t3 = (long *)&t2.tv_sec;
- t5 = math_cast__anon_3035__5194(t0);
+ t5 = math_cast__anon_3113__6121(t0);
  t6 = t5.is_null != true;
  if (t6) {
   t7 = t5.payload;
@@ -3172,7 +3316,7 @@ static void utils_sleep__4219(uint64_t const a0) {
  zig_block_0:;
  (*t3) = t4;
  t3 = (long *)&t2.tv_nsec;
- t5 = math_cast__anon_3035__5194(t1);
+ t5 = math_cast__anon_3113__6121(t1);
  t6 = t5.is_null != true;
  if (t6) {
   t7 = t5.payload;
@@ -3185,8 +3329,8 @@ static void utils_sleep__4219(uint64_t const a0) {
  zig_block_1:;
  (*t3) = t4;
  zig_loop_28:
- t9 = (struct cimport_struct_timespec__3022 const *)&t2;
- t10 = (struct cimport_struct_timespec__3022 *)&t8;
+ t9 = (struct cimport_struct_timespec__3100 const *)&t2;
+ t10 = (struct cimport_struct_timespec__3100 *)&t8;
  t11 = nanosleep(t9, t10);
  t12 = t11;
  t6 = t12 == INT32_C(4);
@@ -3201,13 +3345,13 @@ static void utils_sleep__4219(uint64_t const a0) {
  goto zig_loop_28;
 }
 
-static void shared_Command_deinit__3824(struct shared_Command__1935 const a0, struct mem_Allocator__565 const a1) {
+static void shared_Command_deinit__3836(struct shared_Command__1946 const a0, struct mem_Allocator__565 const a1) {
  struct mem_Allocator__565 const *t1;
- struct shared_Command__struct_1939__1939 t3;
+ struct shared_Command__struct_1950__1950 t3;
  struct mem_Allocator__565 t4;
  struct mem_Allocator__565 t0;
- nav__3824_43 t5;
- struct shared_Command__struct_1938__1938 t6;
+ nav__3836_43 t5;
+ struct shared_Command__struct_1949__1949 t6;
  uint8_t t2;
  t0 = a1;
  t1 = (struct mem_Allocator__565 const *)&t0;
@@ -3217,17 +3361,17 @@ static void shared_Command_deinit__3824(struct shared_Command__1935 const a0, st
    t3 = a0.payload.SetIntegration;
    t4 = (*t1);
    t5 = t3.name;
-   mem_Allocator_free__anon_3110__5963(t4, t5);
+   mem_Allocator_free__anon_3185__6890(t4, t5);
    t4 = (*t1);
    t5 = t3.version;
-   mem_Allocator_free__anon_3110__5963(t4, t5);
+   mem_Allocator_free__anon_3185__6890(t4, t5);
    goto zig_block_0;
   }
   case UINT8_C(0): {
    t6 = a0.payload.ExecutedBenchmark;
    t4 = (*t1);
    t5 = t6.uri;
-   mem_Allocator_free__anon_3110__5963(t4, t5);
+   mem_Allocator_free__anon_3185__6890(t4, t5);
    goto zig_block_0;
   }
   case UINT8_C(8): {
@@ -3242,7 +3386,72 @@ static void shared_Command_deinit__3824(struct shared_Command__1935 const a0, st
  return;
 }
 
-static nav__4222_39 mem_Allocator_allocBytesWithAlignment__anon_2736__4222(struct mem_Allocator__565 const a0, uintptr_t const a1, uintptr_t const a2) {
+static void instruments_perf_PerfInstrument_deinit__752(struct instruments_perf_PerfInstrument__559 *const a0) {
+ struct instruments_perf_PerfInstrument__559 *const *t1;
+ struct instruments_perf_PerfInstrument__559 *t2;
+ struct instruments_perf_PerfInstrument__559 *t0;
+ struct fifo_UnixPipe_Writer__600 *t3;
+ struct fifo_UnixPipe_Reader__602 *t4;
+ t0 = a0;
+ t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
+ t2 = (*t1);
+ t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
+ fifo_UnixPipe_Writer_deinit__1081(t3);
+ t2 = (*t1);
+ t4 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
+ fifo_UnixPipe_Reader_deinit__1088(t4);
+ return;
+}
+
+static void mem_Allocator_destroy__anon_2777__4228(struct mem_Allocator__565 const a0, struct instruments_root_InstrumentHooks__547 *const a1) {
+ struct mem_Allocator__565 const *t1;
+ uint8_t *t2;
+ uint8_t *t3;
+ uint8_t *const *t4;
+ struct mem_Allocator__565 t5;
+ struct mem_Allocator__565 t0;
+ struct mem_Allocator__565 t10;
+ uint8_t (*t6)[72];
+ nav__4228_52 t7;
+ uintptr_t t9;
+ struct mem_Allocator_VTable__568 const *const *t11;
+ struct mem_Allocator_VTable__568 const *t12;
+ void (*const *t13)(void *, nav__4228_52, uint8_t, uintptr_t);
+ void (*t14)(void *, nav__4228_52, uint8_t, uintptr_t);
+ void *t15;
+ uint8_t t8;
+ t0 = a0;
+ t1 = (struct mem_Allocator__565 const *)&t0;
+ t2 = (uint8_t *)a1;
+ t3 = t2;
+ t4 = (uint8_t *const *)&t3;
+ t5 = (*t1);
+ t2 = (*t4);
+ t2 = (uint8_t *)(((uintptr_t)t2) + ((uintptr_t)0ul*sizeof(uint8_t)));
+ t6 = (uint8_t (*)[72])t2;
+ t7.ptr = &(*t6)[(uintptr_t)0ul];
+ t7.len = (uintptr_t)72ul;
+ t8 = mem_Alignment_fromByteUnits__1046((uintptr_t)8ul);
+ t9 = (uintptr_t)zig_return_address();
+ t10 = t5;
+ t1 = (struct mem_Allocator__565 const *)&t10;
+ t11 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
+ t12 = (*t11);
+ t13 = (void (*const *)(void *, nav__4228_52, uint8_t, uintptr_t))&t12->free;
+ t14 = (*t13);
+ t15 = t5.ptr;
+ t14(t15, t7, t8, t9);
+ return;
+}
+
+static zig_noreturn void posix_exit__1442(uint8_t const a0) {
+ int t0;
+ t0 = (int)a0;
+ exit(t0);
+ zig_unreachable();
+}
+
+static nav__4229_39 mem_Allocator_allocBytesWithAlignment__anon_2793__4229(struct mem_Allocator__565 const a0, uintptr_t const a1, uintptr_t const a2) {
  struct mem_Allocator__565 const *t1;
  uint64_t t2;
  uint8_t *t4;
@@ -3258,8 +3467,8 @@ static nav__4222_39 mem_Allocator_allocBytesWithAlignment__anon_2736__4222(struc
  uint8_t *(*t11)(void *, uintptr_t, uint8_t, uintptr_t);
  void *t12;
  uint8_t *const *t16;
- nav__4222_52 t17;
- nav__4222_39 t18;
+ nav__4229_52 t17;
+ nav__4229_39 t18;
  bool t3;
  uint8_t t6;
  t0 = a0;
@@ -3267,13 +3476,13 @@ static nav__4222_39 mem_Allocator_allocBytesWithAlignment__anon_2736__4222(struc
  t2 = a1;
  t3 = t2 == UINT64_C(0);
  if (t3) {
-  return (nav__4222_39){(uint8_t *)(uintptr_t)0xfffffffffffffff8ul,0};
+  return (nav__4229_39){(uint8_t *)(uintptr_t)0xfffffffffffffff8ul,0};
  }
  goto zig_block_0;
 
  zig_block_0:;
  t5 = (*t1);
- t6 = mem_Alignment_fromByteUnits__1045((uintptr_t)8ul);
+ t6 = mem_Alignment_fromByteUnits__1046((uintptr_t)8ul);
  t7 = t5;
  t1 = (struct mem_Allocator__565 const *)&t7;
  t8 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
@@ -3288,7 +3497,7 @@ static nav__4222_39 mem_Allocator_allocBytesWithAlignment__anon_2736__4222(struc
   t4 = t14;
   goto zig_block_1;
  }
- return (nav__4222_39){((uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),zig_error_OutOfMemory};
+ return (nav__4229_39){((uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),zig_error_OutOfMemory};
 
  zig_block_1:;
  t15 = t4;
@@ -3303,31 +3512,31 @@ static nav__4222_39 mem_Allocator_allocBytesWithAlignment__anon_2736__4222(struc
  return t18;
 }
 
-static bool fs_path_isAbsolute__4257(nav__4257_39 const a0) {
+static bool fs_path_isAbsolute__4264(nav__4264_39 const a0) {
  bool t0;
- t0 = fs_path_isAbsolutePosix__4263(a0);
+ t0 = fs_path_isAbsolutePosix__4270(a0);
  return t0;
 }
 
-static struct fs_Dir__1854 fs_cwd__1131(void) {
- struct fs_Dir__1854 t0;
- t0 = (struct fs_Dir__1854){-INT32_C(100)};
+static struct fs_Dir__1860 fs_cwd__1134(void) {
+ struct fs_Dir__1860 t0;
+ t0 = (struct fs_Dir__1860){-INT32_C(100)};
  return t0;
 }
 
-static uint16_t fs_Dir_access__3780(struct fs_Dir__1854 const a0, nav__3780_40 const a1, struct fs_File_OpenFlags__1852 const a2) {
- struct fs_Dir__1854 const *t1;
+static uint16_t fs_Dir_access__3783(struct fs_Dir__1860 const a0, nav__3783_40 const a1, struct fs_File_OpenFlags__1858 const a2) {
+ struct fs_Dir__1860 const *t1;
  uint8_t const (*t6)[4096];
  uint8_t const *t8;
- struct fs_Dir__1854 t7;
- struct fs_Dir__1854 t0;
- nav__3780_49 t2;
+ struct fs_Dir__1860 t7;
+ struct fs_Dir__1860 t0;
+ nav__3783_49 t2;
  uint16_t t3;
  uint8_t t4[4096];
  uint8_t t5[4096];
  t0 = a0;
- t1 = (struct fs_Dir__1854 const *)&t0;
- t2 = posix_toPosixPath__1714(a1);
+ t1 = (struct fs_Dir__1860 const *)&t0;
+ t2 = posix_toPosixPath__1717(a1);
  if (t2.error) {
   t3 = t2.error;
   return t3;
@@ -3337,26 +3546,26 @@ static uint16_t fs_Dir_access__3780(struct fs_Dir__1854 const a0, nav__3780_40 c
  t6 = (uint8_t const (*)[4096])&t5;
  t7 = (*t1);
  t8 = (uint8_t const *)t6;
- t3 = fs_Dir_accessZ__3781(t7, t8, a2);
+ t3 = fs_Dir_accessZ__3784(t7, t8, a2);
  return t3;
 }
 
-static nav__3716_39 fs_Dir_openFile__3716(struct fs_Dir__1854 const a0, nav__3716_42 const a1, struct fs_File_OpenFlags__1852 const a2) {
- struct fs_Dir__1854 const *t1;
+static nav__3719_39 fs_Dir_openFile__3719(struct fs_Dir__1860 const a0, nav__3719_42 const a1, struct fs_File_OpenFlags__1858 const a2) {
+ struct fs_Dir__1860 const *t1;
  uint8_t const (*t8)[4096];
  uint8_t const *t10;
- nav__3716_39 t5;
- struct fs_Dir__1854 t9;
- struct fs_Dir__1854 t0;
- nav__3716_53 t3;
+ nav__3719_39 t5;
+ struct fs_Dir__1860 t9;
+ struct fs_Dir__1860 t0;
+ nav__3719_53 t3;
  uint16_t t4;
  uint8_t t6[4096];
  uint8_t t7[4096];
- struct fs_File_OpenFlags__1852 t2;
+ struct fs_File_OpenFlags__1858 t2;
  t0 = a0;
- t1 = (struct fs_Dir__1854 const *)&t0;
+ t1 = (struct fs_Dir__1860 const *)&t0;
  t2 = a2;
- t3 = posix_toPosixPath__1714(a1);
+ t3 = posix_toPosixPath__1717(a1);
  if (t3.error) {
   t4 = t3.error;
   t5.payload = (struct fs_File__608){-INT32_C(0x55555556)};
@@ -3368,14 +3577,14 @@ static nav__3716_39 fs_Dir_openFile__3716(struct fs_Dir__1854 const a0, nav__371
  t8 = (uint8_t const (*)[4096])&t7;
  t9 = (*t1);
  t10 = (uint8_t const *)t8;
- t5 = fs_Dir_openFileZ__3717(t9, t10, a2);
+ t5 = fs_Dir_openFileZ__3720(t9, t10, a2);
  return t5;
 }
 
-static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__1935 const a1) {
- struct shared_Command__struct_1938__1938 t4;
- struct shared_Command__struct_1939__1939 t5;
- struct shared_Command__struct_1940__1940 t6;
+static uint16_t bincode_serializeUnion__anon_2860__5247(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__1946 const a1) {
+ struct shared_Command__struct_1949__1949 t4;
+ struct shared_Command__struct_1950__1950 t5;
+ struct shared_Command__struct_1951__1951 t6;
  uint64_t t7;
  uint32_t t1;
  uint16_t t2;
@@ -3383,7 +3592,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  bool t3;
  t0 = a1.tag;
  t1 = (uint32_t)t0;
- t2 = bincode_serialize__anon_3184__5976(a0, t1);
+ t2 = bincode_serialize__anon_3275__6904(a0, t1);
  if (t2) {
   return t2;
  }
@@ -3391,7 +3600,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t3 = t0 == UINT8_C(0);
  if (t3) {
   t4 = a1.payload.ExecutedBenchmark;
-  t2 = bincode_serialize__anon_3186__5977(a0, t4);
+  t2 = bincode_serialize__anon_3277__6905(a0, t4);
   if (t2) {
    return t2;
   }
@@ -3403,7 +3612,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t0 = a1.tag;
  t3 = t0 == UINT8_C(1);
  if (t3) {
-  t2 = bincode_serialize__anon_3188__5978(a0);
+  t2 = bincode_serialize__anon_3279__6906(a0);
   if (t2) {
    return t2;
   }
@@ -3415,7 +3624,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t0 = a1.tag;
  t3 = t0 == UINT8_C(2);
  if (t3) {
-  t2 = bincode_serialize__anon_3188__5978(a0);
+  t2 = bincode_serialize__anon_3279__6906(a0);
   if (t2) {
    return t2;
   }
@@ -3427,7 +3636,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t0 = a1.tag;
  t3 = t0 == UINT8_C(3);
  if (t3) {
-  t2 = bincode_serialize__anon_3188__5978(a0);
+  t2 = bincode_serialize__anon_3279__6906(a0);
   if (t2) {
    return t2;
   }
@@ -3439,7 +3648,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t0 = a1.tag;
  t3 = t0 == UINT8_C(4);
  if (t3) {
-  t2 = bincode_serialize__anon_3188__5978(a0);
+  t2 = bincode_serialize__anon_3279__6906(a0);
   if (t2) {
    return t2;
   }
@@ -3452,7 +3661,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t3 = t0 == UINT8_C(5);
  if (t3) {
   t5 = a1.payload.SetIntegration;
-  t2 = bincode_serialize__anon_3190__5979(a0, t5);
+  t2 = bincode_serialize__anon_3281__6907(a0, t5);
   if (t2) {
    return t2;
   }
@@ -3464,7 +3673,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t0 = a1.tag;
  t3 = t0 == UINT8_C(6);
  if (t3) {
-  t2 = bincode_serialize__anon_3188__5978(a0);
+  t2 = bincode_serialize__anon_3279__6906(a0);
   if (t2) {
    return t2;
   }
@@ -3477,7 +3686,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t3 = t0 == UINT8_C(7);
  if (t3) {
   t6 = a1.payload.AddMarker;
-  t2 = bincode_serialize__anon_3192__5980(a0, t6);
+  t2 = bincode_serialize__anon_3283__6908(a0, t6);
   if (t2) {
    return t2;
   }
@@ -3490,7 +3699,7 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  t3 = t0 == UINT8_C(8);
  if (t3) {
   t7 = a1.payload.SetVersion;
-  t2 = bincode_serialize__anon_3194__5981(a0, t7);
+  t2 = bincode_serialize__anon_3285__6909(a0, t7);
   if (t2) {
    return t2;
   }
@@ -3502,17 +3711,17 @@ static uint16_t bincode_serializeUnion__anon_2781__4320(struct io_GenericWriter_
  return 0;
 }
 
-static nav__3924_39 array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3924(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 const a0) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 const *t1;
- nav__3924_39 const *t2;
+static nav__3936_39 array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3936(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 const a0) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 const *t1;
+ nav__3936_39 const *t2;
  uint8_t *const *t3;
  uintptr_t t4;
  uint8_t *t5;
- nav__3924_39 t6;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t0;
+ nav__3936_39 t6;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t0;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 const *)&t0;
- t2 = (nav__3924_39 const *)&t1->items;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 const *)&t0;
+ t2 = (nav__3936_39 const *)&t1->items;
  t3 = &t2->ptr;
  t4 = a0.capacity;
  t5 = (*t3);
@@ -3522,22 +3731,22 @@ static nav__3924_39 array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3
  return t6;
 }
 
-static nav__1229_38 fs_File_write__1229(struct fs_File__608 const a0, nav__1229_41 const a1) {
- nav__1229_38 t1;
+static nav__1232_38 fs_File_write__1232(struct fs_File__608 const a0, nav__1232_41 const a1) {
+ nav__1232_38 t1;
  int32_t t0;
  t0 = a0.handle;
- t1 = posix_write__1449(t0, a1);
+ t1 = posix_write__1452(t0, a1);
  return t1;
 }
 
-static nav__1630_39 posix_clock_gettime__1630(uint32_t const a0) {
- struct os_linux_timespec__struct_2843__2843 t3;
- struct os_linux_timespec__struct_2843__2843 t0;
- nav__1630_39 t4;
+static nav__1633_39 posix_clock_gettime__1633(uint32_t const a0) {
+ struct os_linux_timespec__struct_2922__2922 t3;
+ struct os_linux_timespec__struct_2922__2922 t0;
+ nav__1633_39 t4;
  int t1;
  uint16_t t2;
  t1 = clock_gettime(a0, &t0);
- t2 = posix_errno__anon_3360__6048(t1);
+ t2 = posix_errno__anon_3451__6976(t1);
  switch (t2) {
   case UINT16_C(0): {
    t3 = t0;
@@ -3549,73 +3758,119 @@ static nav__1630_39 posix_clock_gettime__1630(uint32_t const a0) {
    zig_unreachable();
   }
   case UINT16_C(22): {
-   return (nav__1630_39){{-(intptr_t)0x5555555555555556,-(intptr_t)0x5555555555555556},zig_error_UnsupportedClock};
+   return (nav__1633_39){{-(intptr_t)0x5555555555555556,-(intptr_t)0x5555555555555556},zig_error_UnsupportedClock};
   }
   default: {
-   t2 = posix_unexpectedErrno__1713(t2);
-   t4.payload = (struct os_linux_timespec__struct_2843__2843){-(intptr_t)0x5555555555555556,-(intptr_t)0x5555555555555556};
+   t2 = posix_unexpectedErrno__1716(t2);
+   t4.payload = (struct os_linux_timespec__struct_2922__2922){-(intptr_t)0x5555555555555556,-(intptr_t)0x5555555555555556};
    t4.error = t2;
    return t4;
   }
  }
 }
 
-static nav__1219_38 fs_File_read__1219(struct fs_File__608 const a0, nav__1219_41 const a1) {
- nav__1219_38 t1;
+static nav__1222_38 fs_File_read__1222(struct fs_File__608 const a0, nav__1222_41 const a1) {
+ nav__1222_38 t1;
  int32_t t0;
  t0 = a0.handle;
- t1 = posix_read__1441(t0, a1);
+ t1 = posix_read__1444(t0, a1);
  return t1;
 }
 
-static nav__4321_39 mem_Allocator_allocWithSizeAndAlignment__anon_2874__4321(struct mem_Allocator__565 const a0, uintptr_t const a1, uintptr_t const a2) {
+static nav__5248_39 mem_Allocator_allocWithSizeAndAlignment__anon_2953__5248(struct mem_Allocator__565 const a0, uintptr_t const a1, uintptr_t const a2) {
  struct mem_Allocator__565 const *t1;
  uintptr_t t2;
  uintptr_t t5;
- nav__4321_49 t3;
+ nav__5248_49 t3;
  struct mem_Allocator__565 t6;
  struct mem_Allocator__565 t0;
- nav__4321_39 t7;
+ nav__5248_39 t7;
  bool t4;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
- t3 = math_mul__anon_3381__6049((uintptr_t)1ul, a1);
+ t3 = math_mul__anon_3472__6977((uintptr_t)1ul, a1);
  t4 = t3.error == UINT16_C(0);
  if (t4) {
   t5 = t3.payload;
   t2 = t5;
   goto zig_block_0;
  }
- return (nav__4321_39){((uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),zig_error_OutOfMemory};
+ return (nav__5248_39){((uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),zig_error_OutOfMemory};
 
  zig_block_0:;
  t6 = (*t1);
- t7 = mem_Allocator_allocBytesWithAlignment__anon_3383__6050(t6, t2, a2);
+ t7 = mem_Allocator_allocBytesWithAlignment__anon_3474__6978(t6, t2, a2);
  return t7;
 }
 
-static nav__4115_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read__4115(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const a0, nav__4115_42 const a1) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t1;
- nav__4115_42 const *t3;
+static nav__5249_39 mem_sliceAsBytes__anon_2966__5249(nav__5249_39 const a0) {
+ uintptr_t t0;
+ uint64_t t1;
+ uint8_t *t4;
+ uint8_t *t5;
+ uint8_t *const *t6;
+ nav__5249_39 t7;
+ bool t2;
+ bool t3;
+ t0 = a0.len;
+ t1 = t0;
+ t2 = t1 == UINT64_C(0);
+ if (t2) {
+  t3 = true;
+  goto zig_block_1;
+ }
+ t3 = false;
+ goto zig_block_1;
+
+ zig_block_1:;
+ if (t3) {
+  return (nav__5249_39){(uint8_t *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
+ }
+ goto zig_block_0;
+
+ zig_block_0:;
+ t4 = a0.ptr;
+ t5 = t4;
+ t6 = (uint8_t *const *)&t5;
+ t0 = a0.len;
+ t4 = (*t6);
+ t4 = (uint8_t *)(((uintptr_t)t4) + ((uintptr_t)0ul*sizeof(uint8_t)));
+ t7.ptr = t4;
+ t7.len = t0;
+ return t7;
+}
+
+static uint8_t mem_Alignment_fromByteUnits__1046(uintptr_t const a0) {
+ bool t0;
+ uint8_t t1;
+ t0 = math_isPowerOfTwo__anon_3486__6979(a0);
+ debug_assert__180(t0);
+ t1 = zig_ctz_u64(a0, UINT8_C(64));
+ return t1;
+}
+
+static nav__4128_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read__4128(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const a0, nav__4128_42 const a1) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t1;
+ nav__4128_42 const *t3;
  uintptr_t t4;
  uintptr_t t7;
  uintptr_t t9;
- nav__4115_42 *t5;
- nav__4115_42 t6;
- nav__4115_42 t13;
- nav__4115_42 t2;
+ nav__4128_42 *t5;
+ nav__4128_42 t6;
+ nav__4128_42 t13;
+ nav__4128_42 t2;
  uintptr_t *t8;
  uint64_t t10;
  uint8_t *t11;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *t12;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *t0;
- nav__4115_38 t14;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *t12;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *t0;
+ nav__4128_38 t14;
  t0 = a0;
- t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t0;
+ t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t0;
  t2 = a1;
- t3 = (nav__4115_42 const *)&t2;
+ t3 = (nav__4128_42 const *)&t2;
  t4 = a1.len;
- t5 = (nav__4115_42 *)&a0->buffer;
+ t5 = (nav__4128_42 *)&a0->buffer;
  t6 = (*t5);
  t7 = t6.len;
  t8 = (uintptr_t *)&a0->pos;
@@ -3634,7 +3889,7 @@ static nav__4115_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read_
  t6.ptr = t11;
  t6.len = t9;
  t12 = (*t1);
- t5 = (nav__4115_42 *)&t12->buffer;
+ t5 = (nav__4128_42 *)&t12->buffer;
  t8 = (uintptr_t *)&a0->pos;
  t9 = (*t8);
  t13 = (*t5);
@@ -3654,11 +3909,11 @@ static nav__4115_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_read_
  return t14;
 }
 
-static uint16_t io_Reader_readNoEof__4165(struct io_Reader__2307 const a0, nav__4165_40 const a1) {
- struct io_Reader__2307 const *t1;
- struct io_Reader__2307 t2;
- struct io_Reader__2307 t0;
- nav__4165_43 t3;
+static uint16_t io_Reader_readNoEof__4178(struct io_Reader__2337 const a0, nav__4178_40 const a1) {
+ struct io_Reader__2337 const *t1;
+ struct io_Reader__2337 t2;
+ struct io_Reader__2337 t0;
+ nav__4178_43 t3;
  uintptr_t t5;
  uintptr_t t6;
  uint64_t t7;
@@ -3666,9 +3921,9 @@ static uint16_t io_Reader_readNoEof__4165(struct io_Reader__2307 const a0, nav__
  uint16_t t4;
  bool t9;
  t0 = a0;
- t1 = (struct io_Reader__2307 const *)&t0;
+ t1 = (struct io_Reader__2337 const *)&t0;
  t2 = (*t1);
- t3 = io_Reader_readAll__4163(t2, a1);
+ t3 = io_Reader_readAll__4176(t2, a1);
  if (t3.error) {
   t4 = t3.error;
   return t4;
@@ -3687,26 +3942,26 @@ static uint16_t io_Reader_readNoEof__4165(struct io_Reader__2307 const a0, nav__
  return 0;
 }
 
-static nav__4164_38 io_Reader_readAtLeast__4164(struct io_Reader__2307 const a0, nav__4164_41 const a1, uintptr_t const a2) {
- struct io_Reader__2307 const *t1;
- nav__4164_41 const *t3;
+static nav__4177_38 io_Reader_readAtLeast__4177(struct io_Reader__2337 const a0, nav__4177_41 const a1, uintptr_t const a2) {
+ struct io_Reader__2337 const *t1;
+ nav__4177_41 const *t3;
  uintptr_t t4;
  uintptr_t t12;
  uintptr_t t8;
  uint64_t t5;
  uint64_t t6;
- struct io_Reader__2307 t9;
- struct io_Reader__2307 t0;
- nav__4164_41 t10;
- nav__4164_41 t2;
+ struct io_Reader__2337 t9;
+ struct io_Reader__2337 t0;
+ nav__4177_41 t10;
+ nav__4177_41 t2;
  uint8_t *t11;
- nav__4164_38 t13;
+ nav__4177_38 t13;
  uint16_t t14;
  bool t7;
  t0 = a0;
- t1 = (struct io_Reader__2307 const *)&t0;
+ t1 = (struct io_Reader__2337 const *)&t0;
  t2 = a1;
- t3 = (nav__4164_41 const *)&t2;
+ t3 = (nav__4177_41 const *)&t2;
  t4 = a1.len;
  t5 = a2;
  t6 = t4;
@@ -3728,7 +3983,7 @@ static nav__4164_38 io_Reader_readAtLeast__4164(struct io_Reader__2307 const a0,
   t4 = t12 - t4;
   t10.ptr = t11;
   t10.len = t4;
-  t13 = io_Reader_read__4162(t9, t10);
+  t13 = io_Reader_read__4175(t9, t10);
   if (t13.error) {
    t14 = t13.error;
    t13.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
@@ -3761,65 +4016,19 @@ static nav__4164_38 io_Reader_readAtLeast__4164(struct io_Reader__2307 const a0,
  return t13;
 }
 
-static zig_cold zig_noreturn void debug_no_panic_call__4323(nav__4323_39 const a0, nav__4323_40 const a1) {
+static zig_cold zig_noreturn void debug_no_panic_call__5251(nav__5251_39 const a0, nav__5251_40 const a1) {
  (void)a0;
  (void)a1;
  zig_trap();
 }
 
-static nav__4350_39 mem_sliceAsBytes__anon_2993__4350(nav__4350_39 const a0) {
- uintptr_t t0;
- uint64_t t1;
- uint8_t *t4;
- uint8_t *t5;
- uint8_t *const *t6;
- nav__4350_39 t7;
- bool t2;
- bool t3;
- t0 = a0.len;
- t1 = t0;
- t2 = t1 == UINT64_C(0);
- if (t2) {
-  t3 = true;
-  goto zig_block_1;
- }
- t3 = false;
- goto zig_block_1;
-
- zig_block_1:;
- if (t3) {
-  return (nav__4350_39){(uint8_t *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
- }
- goto zig_block_0;
-
- zig_block_0:;
- t4 = a0.ptr;
- t5 = t4;
- t6 = (uint8_t *const *)&t5;
- t0 = a0.len;
- t4 = (*t6);
- t4 = (uint8_t *)(((uintptr_t)t4) + ((uintptr_t)0ul*sizeof(uint8_t)));
- t7.ptr = t4;
- t7.len = t0;
- return t7;
-}
-
-static uint8_t mem_Alignment_fromByteUnits__1045(uintptr_t const a0) {
- bool t0;
- uint8_t t1;
- t0 = math_isPowerOfTwo__anon_3401__6051(a0);
- debug_assert__180(t0);
- t1 = zig_ctz_u64(a0, UINT8_C(64));
- return t1;
-}
-
-static nav__5194_38 math_cast__anon_3035__5194(uint64_t const a0) {
+static nav__6121_38 math_cast__anon_3113__6121(uint64_t const a0) {
  long t1;
- nav__5194_38 t2;
+ nav__6121_38 t2;
  bool t0;
  t0 = a0 > UINT64_C(9223372036854775807);
  if (t0) {
-  return (nav__5194_38){-0x5555555555555556l,true};
+  return (nav__6121_38){-0x5555555555555556l,true};
  }
  t1 = (long)a0;
  t2.is_null = false;
@@ -3827,29 +4036,29 @@ static nav__5194_38 math_cast__anon_3035__5194(uint64_t const a0) {
  return t2;
 }
 
-static void mem_Allocator_free__anon_3110__5963(struct mem_Allocator__565 const a0, nav__5963_40 const a1) {
+static void mem_Allocator_free__anon_3185__6890(struct mem_Allocator__565 const a0, nav__6890_40 const a1) {
  struct mem_Allocator__565 const *t1;
- nav__5963_40 t2;
+ nav__6890_40 t2;
  uintptr_t t3;
  uint64_t t4;
  uint8_t const *t6;
  uint8_t *t7;
  uint8_t *t8;
  uint8_t *const *t9;
- nav__5963_51 t10;
+ nav__6890_51 t10;
  struct mem_Allocator__565 t11;
  struct mem_Allocator__565 t0;
  struct mem_Allocator__565 t13;
  struct mem_Allocator_VTable__568 const *const *t14;
  struct mem_Allocator_VTable__568 const *t15;
- void (*const *t16)(void *, nav__5963_51, uint8_t, uintptr_t);
- void (*t17)(void *, nav__5963_51, uint8_t, uintptr_t);
+ void (*const *t16)(void *, nav__6890_51, uint8_t, uintptr_t);
+ void (*t17)(void *, nav__6890_51, uint8_t, uintptr_t);
  void *t18;
  bool t5;
  uint8_t t12;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
- t2 = mem_sliceAsBytes__anon_3417__6052(a1);
+ t2 = mem_sliceAsBytes__anon_3508__6980(a1);
  t3 = t2.len;
  t4 = t3;
  t5 = t4 == UINT64_C(0);
@@ -3872,20 +4081,50 @@ static void mem_Allocator_free__anon_3110__5963(struct mem_Allocator__565 const 
  t7 = (uint8_t *)(((uintptr_t)t7) + ((uintptr_t)0ul*sizeof(uint8_t)));
  t10.ptr = t7;
  t10.len = t3;
- t12 = mem_Alignment_fromByteUnits__1045((uintptr_t)1ul);
+ t12 = mem_Alignment_fromByteUnits__1046((uintptr_t)1ul);
  t3 = (uintptr_t)zig_return_address();
  t13 = t11;
  t1 = (struct mem_Allocator__565 const *)&t13;
  t14 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
  t15 = (*t14);
- t16 = (void (*const *)(void *, nav__5963_51, uint8_t, uintptr_t))&t15->free;
+ t16 = (void (*const *)(void *, nav__6890_51, uint8_t, uintptr_t))&t15->free;
  t17 = (*t16);
  t18 = t11.ptr;
  t17(t18, t10, t12, t3);
  return;
 }
 
-static bool fs_path_isAbsolutePosix__4263(nav__4263_39 const a0) {
+static void fifo_UnixPipe_Writer_deinit__1081(struct fifo_UnixPipe_Writer__600 *const a0) {
+ struct fifo_UnixPipe_Writer__600 *const *t1;
+ struct fifo_UnixPipe_Writer__600 *t2;
+ struct fifo_UnixPipe_Writer__600 *t0;
+ struct fs_File__608 *t3;
+ struct fs_File__608 t4;
+ t0 = a0;
+ t1 = (struct fifo_UnixPipe_Writer__600 *const *)&t0;
+ t2 = (*t1);
+ t3 = (struct fs_File__608 *)&t2->file;
+ t4 = (*t3);
+ fs_File_close__1179(t4);
+ return;
+}
+
+static void fifo_UnixPipe_Reader_deinit__1088(struct fifo_UnixPipe_Reader__602 *const a0) {
+ struct fifo_UnixPipe_Reader__602 *const *t1;
+ struct fifo_UnixPipe_Reader__602 *t2;
+ struct fifo_UnixPipe_Reader__602 *t0;
+ struct fs_File__608 *t3;
+ struct fs_File__608 t4;
+ t0 = a0;
+ t1 = (struct fifo_UnixPipe_Reader__602 *const *)&t0;
+ t2 = (*t1);
+ t3 = (struct fs_File__608 *)&t2->file;
+ t4 = (*t3);
+ fs_File_close__1179(t4);
+ return;
+}
+
+static bool fs_path_isAbsolutePosix__4270(nav__4270_39 const a0) {
  uintptr_t t0;
  uint64_t t1;
  bool t2;
@@ -3907,13 +4146,13 @@ static bool fs_path_isAbsolutePosix__4263(nav__4263_39 const a0) {
  return t3;
 }
 
-static nav__1714_39 posix_toPosixPath__1714(nav__1714_41 const a0) {
+static nav__1717_39 posix_toPosixPath__1717(nav__1717_41 const a0) {
  uintptr_t t1;
  uint64_t t2;
  uint8_t *t4;
- nav__1714_47 t5;
+ nav__1717_47 t5;
  uint8_t const *t6;
- nav__1714_39 t8;
+ nav__1717_39 t8;
  bool t3;
  uint8_t t7[4096];
  uint8_t t0[4096];
@@ -3921,7 +4160,7 @@ static nav__1714_39 posix_toPosixPath__1714(nav__1714_41 const a0) {
  t2 = t1;
  t3 = t2 >= UINT64_C(4096);
  if (t3) {
-  return (nav__1714_39){zig_error_NameTooLong,{'\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa'}};
+  return (nav__1717_39){zig_error_NameTooLong,{'\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa','\xaa'}};
  }
  goto zig_block_0;
 
@@ -3942,10 +4181,10 @@ static nav__1714_39 posix_toPosixPath__1714(nav__1714_41 const a0) {
  return t8;
 }
 
-static uint16_t fs_Dir_accessZ__3781(struct fs_Dir__1854 const a0, uint8_t const *const a1, struct fs_File_OpenFlags__1852 const a2) {
+static uint16_t fs_Dir_accessZ__3784(struct fs_Dir__1860 const a0, uint8_t const *const a1, struct fs_File_OpenFlags__1858 const a2) {
  uint32_t t2;
  int32_t t3;
- struct fs_Dir__1854 t0;
+ struct fs_Dir__1860 t0;
  uint16_t t4;
  uint8_t t1;
  t0 = a0;
@@ -3968,11 +4207,11 @@ static uint16_t fs_Dir_accessZ__3781(struct fs_Dir__1854 const a0, uint8_t const
 
  zig_block_0:;
  t3 = a0.fd;
- t4 = posix_faccessatZ__1605(t3, a1, t2, UINT32_C(0));
+ t4 = posix_faccessatZ__1608(t3, a1, t2, UINT32_C(0));
  return t4;
 }
 
-static nav__3717_39 fs_Dir_openFileZ__3717(struct fs_Dir__1854 const a0, uint8_t const *const a1, struct fs_File_OpenFlags__1852 const a2) {
+static nav__3720_39 fs_Dir_openFileZ__3720(struct fs_Dir__1860 const a0, uint8_t const *const a1, struct fs_File_OpenFlags__1858 const a2) {
  uint32_t *t2;
  struct fs_File__608 *t14;
  int32_t *t15;
@@ -3981,10 +4220,10 @@ static nav__3717_39 fs_Dir_openFileZ__3717(struct fs_Dir__1854 const a0, uint8_t
  int32_t t12;
  uint32_t t7;
  uint32_t t1;
- nav__3717_50 t8;
- nav__3717_39 t10;
- nav__3717_39 t13;
- struct fs_Dir__1854 t0;
+ nav__3720_50 t8;
+ nav__3720_39 t10;
+ nav__3720_39 t13;
+ struct fs_Dir__1860 t0;
  uint16_t t9;
  uint8_t t3;
  uint8_t t4;
@@ -4056,7 +4295,7 @@ static nav__3717_39 fs_Dir_openFileZ__3717(struct fs_Dir__1854 const a0, uint8_t
  (*t2) = zig_or_u32(zig_and_u32((*t2), UINT32_C(0xfffffeff)), zig_shl_u32((uint32_t)t5, UINT8_C(8)));
  t6 = a0.fd;
  t7 = t1;
- t8 = posix_openatZ__1461(t6, a1, t7, (uintptr_t)0ul);
+ t8 = posix_openatZ__1464(t6, a1, t7, (uintptr_t)0ul);
  if (t8.error) {
   t9 = t8.error;
   t10.payload = (struct fs_File__608){-INT32_C(0x55555556)};
@@ -4095,9 +4334,9 @@ static nav__3717_39 fs_Dir_openFileZ__3717(struct fs_Dir__1854 const a0, uint8_t
   }
 
   zig_block_3:;
-  t9 = posix_flock__1622(t6, t12);
+  t9 = posix_flock__1625(t6, t12);
   if (t9) {
-   posix_close__1419(t6);
+   posix_close__1422(t6);
    t10.payload = (struct fs_File__608){-INT32_C(0x55555556)};
    t10.error = t9;
    return t10;
@@ -4114,62 +4353,62 @@ static nav__3717_39 fs_Dir_openFileZ__3717(struct fs_Dir__1854 const a0, uint8_t
  return t13;
 }
 
-static uint16_t bincode_serialize__anon_3184__5976(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, uint32_t const a1) {
+static uint16_t bincode_serialize__anon_3275__6904(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, uint32_t const a1) {
  uint16_t t0;
- t0 = bincode_serializeInt__anon_3553__6113(a0, a1);
+ t0 = bincode_serializeInt__anon_3646__7041(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3186__5977(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__struct_1938__1938 const a1) {
+static uint16_t bincode_serialize__anon_3277__6905(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__struct_1949__1949 const a1) {
  uint16_t t0;
- t0 = bincode_serializeStruct__anon_3558__6114(a0, a1);
+ t0 = bincode_serializeStruct__anon_3651__7042(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3188__5978(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0) {
+static uint16_t bincode_serialize__anon_3279__6906(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0) {
  (void)a0;
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3190__5979(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__struct_1939__1939 const a1) {
+static uint16_t bincode_serialize__anon_3281__6907(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__struct_1950__1950 const a1) {
  uint16_t t0;
- t0 = bincode_serializeStruct__anon_3559__6115(a0, a1);
+ t0 = bincode_serializeStruct__anon_3652__7043(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3192__5980(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__struct_1940__1940 const a1) {
+static uint16_t bincode_serialize__anon_3283__6908(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__struct_1951__1951 const a1) {
  uint16_t t0;
- t0 = bincode_serializeStruct__anon_3560__6116(a0, a1);
+ t0 = bincode_serializeStruct__anon_3653__7044(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3194__5981(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, uint64_t const a1) {
+static uint16_t bincode_serialize__anon_3285__6909(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, uint64_t const a1) {
  uint16_t t0;
- t0 = bincode_serializeInt__anon_3561__6117(a0, a1);
+ t0 = bincode_serializeInt__anon_3654__7045(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static nav__1449_38 posix_write__1449(int32_t const a0, nav__1449_40 const a1) {
+static nav__1452_38 posix_write__1452(int32_t const a0, nav__1452_40 const a1) {
  uintptr_t t0;
  uint64_t t1;
  uint8_t const *t3;
  intptr_t t5;
- nav__1449_38 t7;
+ nav__1452_38 t7;
  uint32_t t4;
  uint16_t t6;
  bool t2;
@@ -4177,7 +4416,7 @@ static nav__1449_38 posix_write__1449(int32_t const a0, nav__1449_40 const a1) {
  t1 = t0;
  t2 = t1 == UINT64_C(0);
  if (t2) {
-  return (nav__1449_38){(uintptr_t)0ul,0};
+  return (nav__1452_38){(uintptr_t)0ul,0};
  }
  goto zig_block_0;
 
@@ -4189,7 +4428,7 @@ static nav__1449_38 posix_write__1449(int32_t const a0, nav__1449_40 const a1) {
  t4 = (uint32_t)t0;
  t0 = (uintptr_t)t4;
  t5 = write(a0, t3, t0);
- t6 = posix_errno__anon_3572__6119(t5);
+ t6 = posix_errno__anon_3665__7047(t5);
  switch (t6) {
   case UINT16_C(0): {
    t0 = (uintptr_t)t5;
@@ -4201,55 +4440,55 @@ static nav__1449_38 posix_write__1449(int32_t const a0, nav__1449_40 const a1) {
    goto zig_block_1;
   }
   case UINT16_C(22): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_InvalidArgument};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_InvalidArgument};
   }
   case UINT16_C(14): {
    zig_unreachable();
   }
   case UINT16_C(2): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ProcessNotFound};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ProcessNotFound};
   }
   case UINT16_C(11): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_WouldBlock};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_WouldBlock};
   }
   case UINT16_C(9): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NotOpenForWriting};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NotOpenForWriting};
   }
   case UINT16_C(89): {
    zig_unreachable();
   }
   case UINT16_C(122): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_DiskQuota};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_DiskQuota};
   }
   case UINT16_C(27): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_FileTooBig};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_FileTooBig};
   }
   case UINT16_C(5): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_InputOutput};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_InputOutput};
   }
   case UINT16_C(28): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoSpaceLeft};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoSpaceLeft};
   }
   case UINT16_C(13): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_AccessDenied};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_AccessDenied};
   }
   case UINT16_C(1): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_AccessDenied};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_AccessDenied};
   }
   case UINT16_C(32): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_BrokenPipe};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_BrokenPipe};
   }
   case UINT16_C(104): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ConnectionResetByPeer};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ConnectionResetByPeer};
   }
   case UINT16_C(16): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_DeviceBusy};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_DeviceBusy};
   }
   case UINT16_C(6): {
-   return (nav__1449_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoDevice};
+   return (nav__1452_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoDevice};
   }
   default: {
-   t6 = posix_unexpectedErrno__1713(t6);
+   t6 = posix_unexpectedErrno__1716(t6);
    t7.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
    t7.error = t6;
    return t7;
@@ -4260,7 +4499,7 @@ static nav__1449_38 posix_write__1449(int32_t const a0, nav__1449_40 const a1) {
  goto zig_loop_16;
 }
 
-static uint16_t posix_errno__anon_3360__6048(int const a0) {
+static uint16_t posix_errno__anon_3451__6976(int const a0) {
  int *t3;
  int32_t t1;
  int t4;
@@ -4283,17 +4522,17 @@ static uint16_t posix_errno__anon_3360__6048(int const a0) {
  return t0;
 }
 
-static uint16_t posix_unexpectedErrno__1713(uint16_t const a0) {
+static uint16_t posix_unexpectedErrno__1716(uint16_t const a0) {
  (void)a0;
  return zig_error_Unexpected;
 }
 
-static nav__1441_38 posix_read__1441(int32_t const a0, nav__1441_40 const a1) {
+static nav__1444_38 posix_read__1444(int32_t const a0, nav__1444_40 const a1) {
  uintptr_t t0;
  uint64_t t1;
  uint8_t *t3;
  intptr_t t5;
- nav__1441_38 t7;
+ nav__1444_38 t7;
  uint32_t t4;
  uint16_t t6;
  bool t2;
@@ -4301,7 +4540,7 @@ static nav__1441_38 posix_read__1441(int32_t const a0, nav__1441_40 const a1) {
  t1 = t0;
  t2 = t1 == UINT64_C(0);
  if (t2) {
-  return (nav__1441_38){(uintptr_t)0ul,0};
+  return (nav__1444_38){(uintptr_t)0ul,0};
  }
  goto zig_block_0;
 
@@ -4313,7 +4552,7 @@ static nav__1441_38 posix_read__1441(int32_t const a0, nav__1441_40 const a1) {
  t4 = (uint32_t)t0;
  t0 = (uintptr_t)t4;
  t5 = read(a0, t3, t0);
- t6 = posix_errno__anon_3572__6119(t5);
+ t6 = posix_errno__anon_3665__7047(t5);
  switch (t6) {
   case UINT16_C(0): {
    t0 = (uintptr_t)t5;
@@ -4331,40 +4570,40 @@ static nav__1441_38 posix_read__1441(int32_t const a0, nav__1441_40 const a1) {
    zig_unreachable();
   }
   case UINT16_C(2): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ProcessNotFound};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ProcessNotFound};
   }
   case UINT16_C(11): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_WouldBlock};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_WouldBlock};
   }
   case UINT16_C(125): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_Canceled};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_Canceled};
   }
   case UINT16_C(9): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NotOpenForReading};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NotOpenForReading};
   }
   case UINT16_C(5): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_InputOutput};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_InputOutput};
   }
   case UINT16_C(21): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_IsDir};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_IsDir};
   }
   case UINT16_C(105): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_SystemResources};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_SystemResources};
   }
   case UINT16_C(12): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_SystemResources};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_SystemResources};
   }
   case UINT16_C(107): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_SocketNotConnected};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_SocketNotConnected};
   }
   case UINT16_C(104): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ConnectionResetByPeer};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ConnectionResetByPeer};
   }
   case UINT16_C(110): {
-   return (nav__1441_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ConnectionTimedOut};
+   return (nav__1444_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_ConnectionTimedOut};
   }
   default: {
-   t6 = posix_unexpectedErrno__1713(t6);
+   t6 = posix_unexpectedErrno__1716(t6);
    t7.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
    t7.error = t6;
    return t7;
@@ -4375,17 +4614,17 @@ static nav__1441_38 posix_read__1441(int32_t const a0, nav__1441_40 const a1) {
  goto zig_loop_16;
 }
 
-static nav__6049_38 math_mul__anon_3381__6049(uintptr_t const a0, uintptr_t const a1) {
- nav__6049_42 t0;
+static nav__6977_38 math_mul__anon_3472__6977(uintptr_t const a0, uintptr_t const a1) {
+ nav__6977_42 t0;
  uintptr_t t3;
- nav__6049_38 t4;
+ nav__6977_38 t4;
  uint8_t t1;
  bool t2;
  t0.f1 = zig_mulo_u64(&t0.f0, a0, a1, UINT8_C(64));
  t1 = t0.f1;
  t2 = t1 != UINT8_C(0);
  if (t2) {
-  return (nav__6049_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_Overflow};
+  return (nav__6977_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_Overflow};
  }
  goto zig_block_0;
 
@@ -4396,7 +4635,7 @@ static nav__6049_38 math_mul__anon_3381__6049(uintptr_t const a0, uintptr_t cons
  return t4;
 }
 
-static nav__6050_39 mem_Allocator_allocBytesWithAlignment__anon_3383__6050(struct mem_Allocator__565 const a0, uintptr_t const a1, uintptr_t const a2) {
+static nav__6978_39 mem_Allocator_allocBytesWithAlignment__anon_3474__6978(struct mem_Allocator__565 const a0, uintptr_t const a1, uintptr_t const a2) {
  struct mem_Allocator__565 const *t1;
  uint64_t t2;
  uint8_t *t4;
@@ -4412,8 +4651,8 @@ static nav__6050_39 mem_Allocator_allocBytesWithAlignment__anon_3383__6050(struc
  uint8_t *(*t11)(void *, uintptr_t, uint8_t, uintptr_t);
  void *t12;
  uint8_t *const *t16;
- nav__6050_52 t17;
- nav__6050_39 t18;
+ nav__6978_52 t17;
+ nav__6978_39 t18;
  bool t3;
  uint8_t t6;
  t0 = a0;
@@ -4421,13 +4660,13 @@ static nav__6050_39 mem_Allocator_allocBytesWithAlignment__anon_3383__6050(struc
  t2 = a1;
  t3 = t2 == UINT64_C(0);
  if (t3) {
-  return (nav__6050_39){(uint8_t *)UINTPTR_MAX,0};
+  return (nav__6978_39){(uint8_t *)UINTPTR_MAX,0};
  }
  goto zig_block_0;
 
  zig_block_0:;
  t5 = (*t1);
- t6 = mem_Alignment_fromByteUnits__1045((uintptr_t)1ul);
+ t6 = mem_Alignment_fromByteUnits__1046((uintptr_t)1ul);
  t7 = t5;
  t1 = (struct mem_Allocator__565 const *)&t7;
  t8 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
@@ -4442,7 +4681,7 @@ static nav__6050_39 mem_Allocator_allocBytesWithAlignment__anon_3383__6050(struc
   t4 = t14;
   goto zig_block_1;
  }
- return (nav__6050_39){((uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),zig_error_OutOfMemory};
+ return (nav__6978_39){((uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),zig_error_OutOfMemory};
 
  zig_block_1:;
  t15 = t4;
@@ -4456,23 +4695,7 @@ static nav__6050_39 mem_Allocator_allocBytesWithAlignment__anon_3383__6050(struc
  return t18;
 }
 
-static nav__4162_38 io_Reader_read__4162(struct io_Reader__2307 const a0, nav__4162_41 const a1) {
- struct io_Reader__2307 const *t1;
- nav__4162_38 (*const *t2)(void const *, nav__4162_41);
- nav__4162_38 (*t3)(void const *, nav__4162_41);
- void const *t4;
- nav__4162_38 t5;
- struct io_Reader__2307 t0;
- t0 = a0;
- t1 = (struct io_Reader__2307 const *)&t0;
- t2 = (nav__4162_38 (*const *)(void const *, nav__4162_41))&t1->readFn;
- t3 = (*t2);
- t4 = a0.context;
- t5 = t3(t4, a1);
- return t5;
-}
-
-static bool math_isPowerOfTwo__anon_3401__6051(uintptr_t const a0) {
+static bool math_isPowerOfTwo__anon_3486__6979(uintptr_t const a0) {
  uint64_t t0;
  uintptr_t t2;
  bool t1;
@@ -4486,13 +4709,29 @@ static bool math_isPowerOfTwo__anon_3401__6051(uintptr_t const a0) {
  return t1;
 }
 
-static nav__6052_39 mem_sliceAsBytes__anon_3417__6052(nav__6052_39 const a0) {
+static nav__4175_38 io_Reader_read__4175(struct io_Reader__2337 const a0, nav__4175_41 const a1) {
+ struct io_Reader__2337 const *t1;
+ nav__4175_38 (*const *t2)(void const *, nav__4175_41);
+ nav__4175_38 (*t3)(void const *, nav__4175_41);
+ void const *t4;
+ nav__4175_38 t5;
+ struct io_Reader__2337 t0;
+ t0 = a0;
+ t1 = (struct io_Reader__2337 const *)&t0;
+ t2 = (nav__4175_38 (*const *)(void const *, nav__4175_41))&t1->readFn;
+ t3 = (*t2);
+ t4 = a0.context;
+ t5 = t3(t4, a1);
+ return t5;
+}
+
+static nav__6980_39 mem_sliceAsBytes__anon_3508__6980(nav__6980_39 const a0) {
  uintptr_t t0;
  uint64_t t1;
  uint8_t const *t4;
  uint8_t const *t5;
  uint8_t const *const *t6;
- nav__6052_39 t7;
+ nav__6980_39 t7;
  bool t2;
  bool t3;
  t0 = a0.len;
@@ -4507,7 +4746,7 @@ static nav__6052_39 mem_sliceAsBytes__anon_3417__6052(nav__6052_39 const a0) {
 
  zig_block_1:;
  if (t3) {
-  return (nav__6052_39){(uint8_t const *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
+  return (nav__6980_39){(uint8_t const *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
  }
  goto zig_block_0;
 
@@ -4523,7 +4762,14 @@ static nav__6052_39 mem_sliceAsBytes__anon_3417__6052(nav__6052_39 const a0) {
  return t7;
 }
 
-static uint16_t posix_faccessatZ__1605(int32_t const a0, uint8_t const *const a1, uint32_t const a2, uint32_t const a3) {
+static void fs_File_close__1179(struct fs_File__608 const a0) {
+ int32_t t0;
+ t0 = a0.handle;
+ posix_close__1422(t0);
+ return;
+}
+
+static uint16_t posix_faccessatZ__1608(int32_t const a0, uint8_t const *const a1, uint32_t const a2, uint32_t const a3) {
  unsigned int t0;
  unsigned int t1;
  int t2;
@@ -4531,7 +4777,7 @@ static uint16_t posix_faccessatZ__1605(int32_t const a0, uint8_t const *const a1
  t0 = a2;
  t1 = a3;
  t2 = faccessat(a0, a1, t0, t1);
- t3 = posix_errno__anon_3360__6048(t2);
+ t3 = posix_errno__anon_3451__6976(t2);
  switch (t3) {
   case UINT16_C(0): {
    return 0;
@@ -4573,27 +4819,27 @@ static uint16_t posix_faccessatZ__1605(int32_t const a0, uint8_t const *const a1
    return zig_error_SystemResources;
   }
   case UINT16_C(84): {
-   t3 = posix_unexpectedErrno__1713(t3);
+   t3 = posix_unexpectedErrno__1716(t3);
    return t3;
   }
   default: {
-   t3 = posix_unexpectedErrno__1713(t3);
+   t3 = posix_unexpectedErrno__1716(t3);
    return t3;
   }
  }
 }
 
-static nav__1461_38 posix_openatZ__1461(int32_t const a0, uint8_t const *const a1, uint32_t const a2, uintptr_t const a3) {
+static nav__1464_38 posix_openatZ__1464(int32_t const a0, uint8_t const *const a1, uint32_t const a2, uintptr_t const a3) {
  unsigned long t1;
  int t0;
  int32_t t3;
- nav__1461_38 t4;
+ nav__1464_38 t4;
  uint16_t t2;
  zig_loop_11:
  t0 = a0;
  t1 = a3;
  t0 = openat64(t0, a1, a2, t1);
- t2 = posix_errno__anon_3360__6048(t0);
+ t2 = posix_errno__anon_3451__6976(t0);
  switch (t2) {
   case UINT16_C(0): {
    t3 = t0;
@@ -4608,79 +4854,79 @@ static nav__1461_38 posix_openatZ__1461(int32_t const a0, uint8_t const *const a
    zig_unreachable();
   }
   case UINT16_C(22): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_BadPathName};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_BadPathName};
   }
   case UINT16_C(9): {
    zig_unreachable();
   }
   case UINT16_C(13): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_AccessDenied};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_AccessDenied};
   }
   case UINT16_C(27): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_FileTooBig};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_FileTooBig};
   }
   case UINT16_C(75): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_FileTooBig};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_FileTooBig};
   }
   case UINT16_C(21): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_IsDir};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_IsDir};
   }
   case UINT16_C(40): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_SymLinkLoop};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_SymLinkLoop};
   }
   case UINT16_C(24): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_ProcessFdQuotaExceeded};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_ProcessFdQuotaExceeded};
   }
   case UINT16_C(36): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_NameTooLong};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_NameTooLong};
   }
   case UINT16_C(23): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_SystemFdQuotaExceeded};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_SystemFdQuotaExceeded};
   }
   case UINT16_C(19): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_NoDevice};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_NoDevice};
   }
   case UINT16_C(2): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_FileNotFound};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_FileNotFound};
   }
   case UINT16_C(12): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_SystemResources};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_SystemResources};
   }
   case UINT16_C(28): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_NoSpaceLeft};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_NoSpaceLeft};
   }
   case UINT16_C(20): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_NotDir};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_NotDir};
   }
   case UINT16_C(1): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_AccessDenied};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_AccessDenied};
   }
   case UINT16_C(17): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_PathAlreadyExists};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_PathAlreadyExists};
   }
   case UINT16_C(16): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_DeviceBusy};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_DeviceBusy};
   }
   case UINT16_C(95): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_FileLocksNotSupported};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_FileLocksNotSupported};
   }
   case UINT16_C(11): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_WouldBlock};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_WouldBlock};
   }
   case UINT16_C(26): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_FileBusy};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_FileBusy};
   }
   case UINT16_C(6): {
-   return (nav__1461_38){-INT32_C(0x55555556),zig_error_NoDevice};
+   return (nav__1464_38){-INT32_C(0x55555556),zig_error_NoDevice};
   }
   case UINT16_C(84): {
-   t2 = posix_unexpectedErrno__1713(t2);
+   t2 = posix_unexpectedErrno__1716(t2);
    t4.payload = -INT32_C(0x55555556);
    t4.error = t2;
    return t4;
   }
   default: {
-   t2 = posix_unexpectedErrno__1713(t2);
+   t2 = posix_unexpectedErrno__1716(t2);
    t4.payload = -INT32_C(0x55555556);
    t4.error = t2;
    return t4;
@@ -4691,13 +4937,13 @@ static nav__1461_38 posix_openatZ__1461(int32_t const a0, uint8_t const *const a
  goto zig_loop_11;
 }
 
-static uint16_t posix_flock__1622(int32_t const a0, int32_t const a1) {
+static uint16_t posix_flock__1625(int32_t const a0, int32_t const a1) {
  int t0;
  uint16_t t1;
  zig_loop_3:
  t0 = a1;
  t0 = flock(a0, t0);
- t1 = posix_errno__anon_3360__6048(t0);
+ t1 = posix_errno__anon_3451__6976(t0);
  switch (t1) {
   case UINT16_C(0): {
    return 0;
@@ -4721,7 +4967,7 @@ static uint16_t posix_flock__1622(int32_t const a0, int32_t const a1) {
    return zig_error_FileLocksNotSupported;
   }
   default: {
-   t1 = posix_unexpectedErrno__1713(t1);
+   t1 = posix_unexpectedErrno__1716(t1);
    return t1;
   }
  }
@@ -4730,11 +4976,11 @@ static uint16_t posix_flock__1622(int32_t const a0, int32_t const a1) {
  goto zig_loop_3;
 }
 
-static void posix_close__1419(int32_t const a0) {
+static void posix_close__1422(int32_t const a0) {
  int t0;
  uint16_t t1;
  t0 = close(a0);
- t1 = posix_errno__anon_3360__6048(t0);
+ t1 = posix_errno__anon_3451__6976(t0);
  switch (t1) {
   case UINT16_C(9): {
    zig_unreachable();
@@ -4748,53 +4994,53 @@ static void posix_close__1419(int32_t const a0) {
  }
 }
 
-static uint16_t bincode_serializeInt__anon_3553__6113(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, uint32_t const a1) {
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t1;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t4;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t2;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t0;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t3;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *t5;
+static uint16_t bincode_serializeInt__anon_3646__7041(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, uint32_t const a1) {
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t1;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t4;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t2;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t0;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t3;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *t5;
  void const **t7;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t8;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t8;
  void const *t9;
- nav__6113_48 (**t10)(void const *, nav__6113_50);
- struct io_Writer__3831 t11;
- struct io_Writer__3831 t6;
- struct io_Writer__3831 t12;
- struct io_Writer__3831 t14;
- struct io_Writer__3831 const *t13;
- nav__6113_50 t17;
+ nav__7041_48 (**t10)(void const *, nav__7041_50);
+ struct io_Writer__3920 t11;
+ struct io_Writer__3920 t6;
+ struct io_Writer__3920 t12;
+ struct io_Writer__3920 t14;
+ struct io_Writer__3920 const *t13;
+ nav__7041_50 t17;
  uint16_t t18;
  uint16_t t19;
  uint8_t t16[4];
  uint8_t t15[4];
  t0 = a0;
- t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t0;
+ t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t0;
  t2 = (*t1);
  t3 = t2;
- t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t3;
+ t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t3;
  t4 = t1;
- t5 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *)&t4;
+ t5 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *)&t4;
  t7 = (void const **)&t6.context;
  t1 = (*t5);
- t8 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t1->context;
+ t8 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t1->context;
  t9 = (void const *)t8;
  (*t7) = t9;
- t10 = (nav__6113_48 (**)(void const *, nav__6113_50))&t6.writeFn;
- (*t10) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4048;
+ t10 = (nav__7041_48 (**)(void const *, nav__7041_50))&t6.writeFn;
+ (*t10) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4060;
  t11 = t6;
  t12 = t11;
- t13 = (struct io_Writer__3831 const *)&t12;
+ t13 = (struct io_Writer__3920 const *)&t12;
  t11 = (*t13);
  t14 = t11;
- t13 = (struct io_Writer__3831 const *)&t14;
+ t13 = (struct io_Writer__3920 const *)&t14;
  memcpy(&t16, &a1, sizeof(uint8_t[4]));
  memcpy((char *)&t15, t16, sizeof(uint8_t[4]));
  t11 = (*t13);
  t17.ptr = &t15[(uintptr_t)0ul];
  t17.len = (uintptr_t)4ul;
- t18 = io_Writer_writeAll__6132(t11, t17);
+ t18 = io_Writer_writeAll__7060(t11, t17);
  memcpy(&t19, &t18, sizeof(uint16_t));
  if (t19) {
   return t19;
@@ -4802,103 +5048,103 @@ static uint16_t bincode_serializeInt__anon_3553__6113(struct io_GenericWriter_28
  return 0;
 }
 
-static uint16_t bincode_serializeStruct__anon_3558__6114(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__struct_1938__1938 const a1) {
- nav__6114_45 t2;
+static uint16_t bincode_serializeStruct__anon_3651__7042(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__struct_1949__1949 const a1) {
+ nav__7042_45 t2;
  uint32_t t0;
  uint16_t t1;
  t0 = a1.pid;
- t1 = bincode_serialize__anon_3184__5976(a0, t0);
+ t1 = bincode_serialize__anon_3275__6904(a0, t0);
  if (t1) {
   return t1;
  }
  t2 = a1.uri;
- t1 = bincode_serialize__anon_3867__6141(a0, t2);
+ t1 = bincode_serialize__anon_3956__7069(a0, t2);
  if (t1) {
   return t1;
  }
  return 0;
 }
 
-static uint16_t bincode_serializeStruct__anon_3559__6115(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__struct_1939__1939 const a1) {
- nav__6115_45 t0;
+static uint16_t bincode_serializeStruct__anon_3652__7043(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__struct_1950__1950 const a1) {
+ nav__7043_45 t0;
  uint16_t t1;
  t0 = a1.name;
- t1 = bincode_serialize__anon_3867__6141(a0, t0);
+ t1 = bincode_serialize__anon_3956__7069(a0, t0);
  if (t1) {
   return t1;
  }
  t0 = a1.version;
- t1 = bincode_serialize__anon_3867__6141(a0, t0);
+ t1 = bincode_serialize__anon_3956__7069(a0, t0);
  if (t1) {
   return t1;
  }
  return 0;
 }
 
-static uint16_t bincode_serializeStruct__anon_3560__6116(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_Command__struct_1940__1940 const a1) {
- struct shared_MarkerType__1942 t2;
+static uint16_t bincode_serializeStruct__anon_3653__7044(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_Command__struct_1951__1951 const a1) {
+ struct shared_MarkerType__1953 t2;
  uint32_t t0;
  uint16_t t1;
  t0 = a1.pid;
- t1 = bincode_serialize__anon_3184__5976(a0, t0);
+ t1 = bincode_serialize__anon_3275__6904(a0, t0);
  if (t1) {
   return t1;
  }
  t2 = a1.marker;
- t1 = bincode_serialize__anon_3869__6142(a0, t2);
+ t1 = bincode_serialize__anon_3958__7070(a0, t2);
  if (t1) {
   return t1;
  }
  return 0;
 }
 
-static uint16_t bincode_serializeInt__anon_3561__6117(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, uint64_t const a1) {
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t1;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t4;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t2;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t0;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t3;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *t5;
+static uint16_t bincode_serializeInt__anon_3654__7045(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, uint64_t const a1) {
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t1;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t4;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t2;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t0;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t3;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *t5;
  void const **t7;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t8;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t8;
  void const *t9;
- nav__6117_48 (**t10)(void const *, nav__6117_50);
- struct io_Writer__3831 t11;
- struct io_Writer__3831 t6;
- struct io_Writer__3831 t12;
- struct io_Writer__3831 t14;
- struct io_Writer__3831 const *t13;
- nav__6117_50 t17;
+ nav__7045_48 (**t10)(void const *, nav__7045_50);
+ struct io_Writer__3920 t11;
+ struct io_Writer__3920 t6;
+ struct io_Writer__3920 t12;
+ struct io_Writer__3920 t14;
+ struct io_Writer__3920 const *t13;
+ nav__7045_50 t17;
  uint16_t t18;
  uint16_t t19;
  uint8_t t16[8];
  uint8_t t15[8];
  t0 = a0;
- t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t0;
+ t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t0;
  t2 = (*t1);
  t3 = t2;
- t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t3;
+ t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t3;
  t4 = t1;
- t5 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *)&t4;
+ t5 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *)&t4;
  t7 = (void const **)&t6.context;
  t1 = (*t5);
- t8 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t1->context;
+ t8 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t1->context;
  t9 = (void const *)t8;
  (*t7) = t9;
- t10 = (nav__6117_48 (**)(void const *, nav__6117_50))&t6.writeFn;
- (*t10) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4048;
+ t10 = (nav__7045_48 (**)(void const *, nav__7045_50))&t6.writeFn;
+ (*t10) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4060;
  t11 = t6;
  t12 = t11;
- t13 = (struct io_Writer__3831 const *)&t12;
+ t13 = (struct io_Writer__3920 const *)&t12;
  t11 = (*t13);
  t14 = t11;
- t13 = (struct io_Writer__3831 const *)&t14;
+ t13 = (struct io_Writer__3920 const *)&t14;
  memcpy(&t16, &a1, sizeof(uint8_t[8]));
  memcpy((char *)&t15, t16, sizeof(uint8_t[8]));
  t11 = (*t13);
  t17.ptr = &t15[(uintptr_t)0ul];
  t17.len = (uintptr_t)8ul;
- t18 = io_Writer_writeAll__6132(t11, t17);
+ t18 = io_Writer_writeAll__7060(t11, t17);
  memcpy(&t19, &t18, sizeof(uint16_t));
  if (t19) {
   return t19;
@@ -4906,7 +5152,7 @@ static uint16_t bincode_serializeInt__anon_3561__6117(struct io_GenericWriter_28
  return 0;
 }
 
-static uint16_t posix_errno__anon_3572__6119(intptr_t const a0) {
+static uint16_t posix_errno__anon_3665__7047(intptr_t const a0) {
  int64_t t1;
  int *t3;
  int t4;
@@ -4929,39 +5175,39 @@ static uint16_t posix_errno__anon_3572__6119(intptr_t const a0) {
  return t0;
 }
 
-static nav__4048_38 io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4048(void const *const a0, nav__4048_41 const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t0;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t1;
- nav__4048_38 t2;
- nav__4048_38 t3;
- t0 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)a0;
+static nav__4060_38 io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4060(void const *const a0, nav__4060_41 const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t0;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t1;
+ nav__4060_38 t2;
+ nav__4060_38 t3;
+ t0 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)a0;
  t1 = (*t0);
- t2 = array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3902(t1, a1);
- memcpy(&t3, &t2, sizeof(nav__4048_38));
+ t2 = array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3914(t1, a1);
+ memcpy(&t3, &t2, sizeof(nav__4060_38));
  return t3;
 }
 
-static uint16_t io_Writer_writeAll__6132(struct io_Writer__3831 const a0, nav__6132_40 const a1) {
- struct io_Writer__3831 const *t1;
- nav__6132_40 const *t3;
+static uint16_t io_Writer_writeAll__7060(struct io_Writer__3920 const a0, nav__7060_40 const a1) {
+ struct io_Writer__3920 const *t1;
+ nav__7060_40 const *t3;
  uintptr_t t5;
  uintptr_t t6;
  uintptr_t t13;
  uintptr_t t4;
  uint64_t t7;
  uint64_t t8;
- struct io_Writer__3831 t10;
- struct io_Writer__3831 t0;
- nav__6132_40 t11;
- nav__6132_40 t2;
+ struct io_Writer__3920 t10;
+ struct io_Writer__3920 t0;
+ nav__7060_40 t11;
+ nav__7060_40 t2;
  uint8_t const *t12;
- nav__6132_43 t14;
+ nav__7060_43 t14;
  uint16_t t15;
  bool t9;
  t0 = a0;
- t1 = (struct io_Writer__3831 const *)&t0;
+ t1 = (struct io_Writer__3920 const *)&t0;
  t2 = a1;
- t3 = (nav__6132_40 const *)&t2;
+ t3 = (nav__7060_40 const *)&t2;
  t4 = (uintptr_t)0ul;
  zig_loop_11:
  t5 = t4;
@@ -4980,7 +5226,7 @@ static uint16_t io_Writer_writeAll__6132(struct io_Writer__3831 const a0, nav__6
   t5 = t13 - t5;
   t11.ptr = t12;
   t11.len = t5;
-  t14 = io_Writer_write__6131(t10, t11);
+  t14 = io_Writer_write__7059(t10, t11);
   if (t14.error) {
    t15 = t14.error;
    return t15;
@@ -4999,35 +5245,35 @@ static uint16_t io_Writer_writeAll__6132(struct io_Writer__3831 const a0, nav__6
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3867__6141(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, nav__6141_40 const a1) {
+static uint16_t bincode_serialize__anon_3956__7069(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, nav__7069_40 const a1) {
  uint16_t t0;
- t0 = bincode_serializePointer__anon_3882__6143(a0, a1);
+ t0 = bincode_serializePointer__anon_3971__7071(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static uint16_t bincode_serialize__anon_3869__6142(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_MarkerType__1942 const a1) {
+static uint16_t bincode_serialize__anon_3958__7070(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_MarkerType__1953 const a1) {
  uint16_t t0;
- t0 = bincode_serializeUnion__anon_3883__6144(a0, a1);
+ t0 = bincode_serializeUnion__anon_3972__7072(a0, a1);
  if (t0) {
   return t0;
  }
  return 0;
 }
 
-static nav__3902_38 array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3902(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0, nav__3902_42 const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t1;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t2;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t0;
- nav__3902_38 t4;
+static nav__3914_38 array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3914(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0, nav__3914_42 const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t1;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t2;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t0;
+ nav__3914_38 t4;
  uintptr_t t5;
  uint16_t t3;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t0;
  t2 = (*t1);
- t3 = array_list_ArrayListAligned_28u8_2cnull_29_appendSlice__3896(t2, a1);
+ t3 = array_list_ArrayListAligned_28u8_2cnull_29_appendSlice__3908(t2, a1);
  if (t3) {
   t4.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
   t4.error = t3;
@@ -5039,99 +5285,99 @@ static nav__3902_38 array_list_ArrayListAligned_28u8_2cnull_29_appendWrite__3902
  return t4;
 }
 
-static nav__6131_38 io_Writer_write__6131(struct io_Writer__3831 const a0, nav__6131_41 const a1) {
- struct io_Writer__3831 const *t1;
- nav__6131_38 (*const *t2)(void const *, nav__6131_41);
- nav__6131_38 (*t3)(void const *, nav__6131_41);
+static nav__7059_38 io_Writer_write__7059(struct io_Writer__3920 const a0, nav__7059_41 const a1) {
+ struct io_Writer__3920 const *t1;
+ nav__7059_38 (*const *t2)(void const *, nav__7059_41);
+ nav__7059_38 (*t3)(void const *, nav__7059_41);
  void const *t4;
- nav__6131_38 t5;
- struct io_Writer__3831 t0;
+ nav__7059_38 t5;
+ struct io_Writer__3920 t0;
  t0 = a0;
- t1 = (struct io_Writer__3831 const *)&t0;
- t2 = (nav__6131_38 (*const *)(void const *, nav__6131_41))&t1->writeFn;
+ t1 = (struct io_Writer__3920 const *)&t0;
+ t2 = (nav__7059_38 (*const *)(void const *, nav__7059_41))&t1->writeFn;
  t3 = (*t2);
  t4 = a0.context;
  t5 = t3(t4, a1);
  return t5;
 }
 
-static uint16_t bincode_serializePointer__anon_3882__6143(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, nav__6143_40 const a1) {
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t1;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t6;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t7;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *t24;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t2;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t0;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t5;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 t23;
+static uint16_t bincode_serializePointer__anon_3971__7071(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, nav__7071_40 const a1) {
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t1;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t6;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t7;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *t24;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t2;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t0;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t5;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 t23;
  uintptr_t t3;
  uint64_t t4;
- struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *t8;
+ struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *t8;
  void const **t10;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t11;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t11;
  void const *t12;
- nav__6143_51 (**t13)(void const *, nav__6143_40);
- struct io_Writer__3831 t14;
- struct io_Writer__3831 t9;
- struct io_Writer__3831 t15;
- struct io_Writer__3831 t17;
- struct io_Writer__3831 t25;
- struct io_Writer__3831 t26;
- struct io_Writer__3831 const *t16;
- nav__6143_40 t20;
+ nav__7071_51 (**t13)(void const *, nav__7071_40);
+ struct io_Writer__3920 t14;
+ struct io_Writer__3920 t9;
+ struct io_Writer__3920 t15;
+ struct io_Writer__3920 t17;
+ struct io_Writer__3920 t25;
+ struct io_Writer__3920 t26;
+ struct io_Writer__3920 const *t16;
+ nav__7071_40 t20;
  uint16_t t21;
  uint16_t t22;
  uint8_t t19[8];
  uint8_t t18[8];
  t0 = a0;
- t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t0;
+ t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t0;
  t2 = (*t1);
  t3 = a1.len;
  t4 = t3;
  t5 = t2;
- t6 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t5;
+ t6 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t5;
  t7 = t6;
- t8 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *)&t7;
+ t8 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *)&t7;
  t10 = (void const **)&t9.context;
  t6 = (*t8);
- t11 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t6->context;
+ t11 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t6->context;
  t12 = (void const *)t11;
  (*t10) = t12;
- t13 = (nav__6143_51 (**)(void const *, nav__6143_40))&t9.writeFn;
- (*t13) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4048;
+ t13 = (nav__7071_51 (**)(void const *, nav__7071_40))&t9.writeFn;
+ (*t13) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4060;
  t14 = t9;
  t15 = t14;
- t16 = (struct io_Writer__3831 const *)&t15;
+ t16 = (struct io_Writer__3920 const *)&t15;
  t14 = (*t16);
  t17 = t14;
- t16 = (struct io_Writer__3831 const *)&t17;
+ t16 = (struct io_Writer__3920 const *)&t17;
  memcpy(&t19, &t4, sizeof(uint8_t[8]));
  memcpy((char *)&t18, t19, sizeof(uint8_t[8]));
  t14 = (*t16);
  t20.ptr = &t18[(uintptr_t)0ul];
  t20.len = (uintptr_t)8ul;
- t21 = io_Writer_writeAll__6132(t14, t20);
+ t21 = io_Writer_writeAll__7060(t14, t20);
  memcpy(&t22, &t21, sizeof(uint16_t));
  if (t22) {
   return t22;
  }
  t2 = (*t1);
  t23 = t2;
- t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *)&t23;
+ t1 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *)&t23;
  t24 = t1;
- t8 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const *const *)&t24;
+ t8 = (struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const *const *)&t24;
  t10 = (void const **)&t25.context;
  t1 = (*t8);
- t11 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t1->context;
+ t11 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t1->context;
  t12 = (void const *)t11;
  (*t10) = t12;
- t13 = (nav__6143_51 (**)(void const *, nav__6143_40))&t25.writeFn;
- (*t13) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4048;
+ t13 = (nav__7071_51 (**)(void const *, nav__7071_40))&t25.writeFn;
+ (*t13) = &io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29___4060;
  t14 = t25;
  t26 = t14;
- t16 = (struct io_Writer__3831 const *)&t26;
+ t16 = (struct io_Writer__3920 const *)&t26;
  t14 = (*t16);
- t22 = io_Writer_writeAll__6132(t14, a1);
+ t22 = io_Writer_writeAll__7060(t14, a1);
  memcpy(&t21, &t22, sizeof(uint16_t));
  if (t21) {
   return t21;
@@ -5139,7 +5385,7 @@ static uint16_t bincode_serializePointer__anon_3882__6143(struct io_GenericWrite
  return 0;
 }
 
-static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__1994 const a0, struct shared_MarkerType__1942 const a1) {
+static uint16_t bincode_serializeUnion__anon_3972__7072(struct io_GenericWriter_28_2aarray_list_ArrayListAligned_28u8_2cnull_29_2cerror_7bOutOfMemory_7d_2c_28function_20_27appendWrite_27_29_29__2005 const a0, struct shared_MarkerType__1953 const a1) {
  uint64_t t4;
  uint32_t t1;
  uint16_t t2;
@@ -5147,7 +5393,7 @@ static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_
  bool t3;
  t0 = a1.tag;
  t1 = (uint32_t)t0;
- t2 = bincode_serialize__anon_3184__5976(a0, t1);
+ t2 = bincode_serialize__anon_3275__6904(a0, t1);
  if (t2) {
   return t2;
  }
@@ -5155,7 +5401,7 @@ static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_
  t3 = t0 == UINT8_C(0);
  if (t3) {
   t4 = a1.payload.SampleStart;
-  t2 = bincode_serialize__anon_3194__5981(a0, t4);
+  t2 = bincode_serialize__anon_3285__6909(a0, t4);
   if (t2) {
    return t2;
   }
@@ -5168,7 +5414,7 @@ static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_
  t3 = t0 == UINT8_C(1);
  if (t3) {
   t4 = a1.payload.SampleEnd;
-  t2 = bincode_serialize__anon_3194__5981(a0, t4);
+  t2 = bincode_serialize__anon_3285__6909(a0, t4);
   if (t2) {
    return t2;
   }
@@ -5181,7 +5427,7 @@ static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_
  t3 = t0 == UINT8_C(2);
  if (t3) {
   t4 = a1.payload.BenchmarkStart;
-  t2 = bincode_serialize__anon_3194__5981(a0, t4);
+  t2 = bincode_serialize__anon_3285__6909(a0, t4);
   if (t2) {
    return t2;
   }
@@ -5194,7 +5440,7 @@ static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_
  t3 = t0 == UINT8_C(3);
  if (t3) {
   t4 = a1.payload.BenchmarkEnd;
-  t2 = bincode_serialize__anon_3194__5981(a0, t4);
+  t2 = bincode_serialize__anon_3285__6909(a0, t4);
   if (t2) {
    return t2;
   }
@@ -5206,68 +5452,68 @@ static uint16_t bincode_serializeUnion__anon_3883__6144(struct io_GenericWriter_
  return 0;
 }
 
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_appendSlice__3896(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0, nav__3896_41 const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t1;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t2;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t0;
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_appendSlice__3908(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0, nav__3908_41 const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t1;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t2;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t0;
  uintptr_t t3;
  uint16_t t4;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t0;
  t2 = (*t1);
  t3 = a1.len;
- t4 = array_list_ArrayListAligned_28u8_2cnull_29_ensureUnusedCapacity__3915(t2, t3);
+ t4 = array_list_ArrayListAligned_28u8_2cnull_29_ensureUnusedCapacity__3927(t2, t3);
  if (t4) {
   return t4;
  }
  t2 = (*t1);
- array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity__3897(t2, a1);
+ array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity__3909(t2, a1);
  return 0;
 }
 
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureUnusedCapacity__3915(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0, uintptr_t const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t1;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t2;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t0;
- nav__3915_43 *t3;
- nav__3915_43 t4;
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureUnusedCapacity__3927(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0, uintptr_t const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t1;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t2;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t0;
+ nav__3927_43 *t3;
+ nav__3927_43 t4;
  uintptr_t t5;
- nav__3915_52 t6;
+ nav__3927_52 t6;
  uint16_t t7;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t0;
  t2 = (*t1);
- t3 = (nav__3915_43 *)&a0->items;
+ t3 = (nav__3927_43 *)&a0->items;
  t4 = (*t3);
  t5 = t4.len;
- t6 = array_list_addOrOom__3840(t5, a1);
+ t6 = array_list_addOrOom__3852(t5, a1);
  if (t6.error) {
   t7 = t6.error;
   return t7;
  }
  t5 = t6.payload;
- t7 = array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__3913(t2, t5);
+ t7 = array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__3925(t2, t5);
  return t7;
 }
 
-static void array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity__3897(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0, nav__3897_41 const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t1;
- nav__3897_47 *t2;
- nav__3897_47 t3;
+static void array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity__3909(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0, nav__3909_41 const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t1;
+ nav__3909_47 *t2;
+ nav__3909_47 t3;
  uintptr_t t4;
  uintptr_t t5;
  uintptr_t t7;
  uintptr_t *t6;
  uint64_t t8;
  uint64_t t9;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t11;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t0;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t11;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t0;
  uint8_t *t12;
  uint8_t const *t13;
  bool t10;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t0;
- t2 = (nav__3897_47 *)&a0->items;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t0;
+ t2 = (nav__3909_47 *)&a0->items;
  t3 = (*t2);
  t4 = t3.len;
  t5 = a1.len;
@@ -5279,11 +5525,11 @@ static void array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity
  t10 = t8 <= t9;
  debug_assert__180(t10);
  t11 = (*t1);
- t2 = (nav__3897_47 *)&t11->items;
+ t2 = (nav__3909_47 *)&t11->items;
  t6 = &t2->len;
  (*t6) = t5;
  t11 = (*t1);
- t2 = (nav__3897_47 *)&t11->items;
+ t2 = (nav__3909_47 *)&t11->items;
  t5 = a1.len;
  t3 = (*t2);
  t12 = t3.ptr;
@@ -5295,13 +5541,13 @@ static void array_list_ArrayListAligned_28u8_2cnull_29_appendSliceAssumeCapacity
  return;
 }
 
-static nav__3840_38 array_list_addOrOom__3840(uintptr_t const a0, uintptr_t const a1) {
- nav__3840_42 t2;
+static nav__3852_38 array_list_addOrOom__3852(uintptr_t const a0, uintptr_t const a1) {
+ nav__3852_42 t2;
  uintptr_t t3;
  uintptr_t t0;
  uintptr_t const *t5;
  uint8_t const *t6;
- nav__3840_38 t8;
+ nav__3852_38 t8;
  uint8_t t4;
  uint8_t t1;
  bool t7;
@@ -5315,7 +5561,7 @@ static nav__3840_38 array_list_addOrOom__3840(uintptr_t const a0, uintptr_t cons
  t4 = (*t6);
  t7 = t4 != UINT8_C(0);
  if (t7) {
-  return (nav__3840_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_OutOfMemory};
+  return (nav__3852_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_OutOfMemory};
  }
  goto zig_block_0;
 
@@ -5326,18 +5572,18 @@ static nav__3840_38 array_list_addOrOom__3840(uintptr_t const a0, uintptr_t cons
  return t8;
 }
 
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__3913(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0, uintptr_t const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t1;
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__3925(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0, uintptr_t const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t1;
  uintptr_t *t2;
  uintptr_t t3;
  uint64_t t4;
  uint64_t t5;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t7;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t0;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t7;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t0;
  uint16_t t8;
  bool t6;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t0;
  t2 = (uintptr_t *)&a0->capacity;
  t3 = (*t2);
  t4 = t3;
@@ -5351,13 +5597,13 @@ static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacity__
  zig_block_0:;
  t2 = (uintptr_t *)&a0->capacity;
  t3 = (*t2);
- t3 = array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacity__6203(t3, a1);
+ t3 = array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacity__7131(t3, a1);
  t7 = (*t1);
- t8 = array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPrecise__3914(t7, t3);
+ t8 = array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPrecise__3926(t7, t3);
  return t8;
 }
 
-static uintptr_t array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacity__6203(uintptr_t const a0, uintptr_t const a1) {
+static uintptr_t array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacity__7131(uintptr_t const a0, uintptr_t const a1) {
  uintptr_t t1;
  uintptr_t t2;
  uintptr_t t0;
@@ -5386,31 +5632,31 @@ static uintptr_t array_list_ArrayListAlignedUnmanaged_28u8_2cnull_29_growCapacit
  goto zig_loop_6;
 }
 
-static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPrecise__3914(struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const a0, uintptr_t const a1) {
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *t1;
+static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPrecise__3926(struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const a0, uintptr_t const a1) {
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *t1;
  uintptr_t *t2;
  uintptr_t t3;
  uint64_t t4;
  uint64_t t5;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t7;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *t0;
- struct array_list_ArrayListAligned_28u8_2cnull_29__1963 t8;
- nav__3914_43 t9;
- nav__3914_43 t12;
- nav__3914_43 t20;
- nav__3914_43 t21;
- nav__3914_43 t18;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t7;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *t0;
+ struct array_list_ArrayListAligned_28u8_2cnull_29__1974 t8;
+ nav__3926_43 t9;
+ nav__3926_43 t12;
+ nav__3926_43 t20;
+ nav__3926_43 t21;
+ nav__3926_43 t18;
  struct mem_Allocator__565 *t10;
  struct mem_Allocator__565 t11;
- nav__3914_43 *t13;
+ nav__3926_43 *t13;
  uint8_t **t14;
  uint8_t *t15;
- nav__3914_55 t16;
- nav__3914_43 const *t19;
+ nav__3926_55 t16;
+ nav__3926_43 const *t19;
  uint16_t t17;
  bool t6;
  t0 = a0;
- t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1963 *const *)&t0;
+ t1 = (struct array_list_ArrayListAligned_28u8_2cnull_29__1974 *const *)&t0;
  t2 = (uintptr_t *)&a0->capacity;
  t3 = (*t2);
  t4 = t3;
@@ -5424,16 +5670,16 @@ static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPr
  zig_block_0:;
  t7 = (*t1);
  t8 = (*t7);
- t9 = array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3924(t8);
+ t9 = array_list_ArrayListAligned_28u8_2cnull_29_allocatedSlice__3936(t8);
  t7 = (*t1);
  t10 = (struct mem_Allocator__565 *)&t7->allocator;
  t11 = (*t10);
- t12 = mem_Allocator_remap__anon_3940__6230(t11, t9, a1);
+ t12 = mem_Allocator_remap__anon_4029__7158(t11, t9, a1);
  t6 = t12.ptr != NULL;
  if (t6) {
   t9 = t12;
   t7 = (*t1);
-  t13 = (nav__3914_43 *)&t7->items;
+  t13 = (nav__3926_43 *)&t7->items;
   t14 = &t13->ptr;
   t15 = t9.ptr;
   (*t14) = t15;
@@ -5446,15 +5692,15 @@ static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPr
  t7 = (*t1);
  t10 = (struct mem_Allocator__565 *)&t7->allocator;
  t11 = (*t10);
- t16 = mem_Allocator_alignedAlloc__anon_3945__6231(t11, a1);
+ t16 = mem_Allocator_alignedAlloc__anon_4034__7159(t11, a1);
  if (t16.error) {
   t17 = t16.error;
   return t17;
  }
  t12 = t16.payload;
  t18 = t12;
- t19 = (nav__3914_43 const *)&t18;
- t13 = (nav__3914_43 *)&a0->items;
+ t19 = (nav__3926_43 const *)&t18;
+ t13 = (nav__3926_43 *)&a0->items;
  t20 = (*t13);
  t3 = t20.len;
  t20 = (*t19);
@@ -5462,16 +5708,16 @@ static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPr
  t15 = (uint8_t *)(((uintptr_t)t15) + ((uintptr_t)0ul*sizeof(uint8_t)));
  t20.ptr = t15;
  t20.len = t3;
- t13 = (nav__3914_43 *)&a0->items;
+ t13 = (nav__3926_43 *)&a0->items;
  t21 = (*t13);
  t15 = t21.ptr;
  if (t20.len != 0) memcpy(t20.ptr, t15, t20.len * sizeof(uint8_t));
  t7 = (*t1);
  t10 = (struct mem_Allocator__565 *)&t7->allocator;
  t11 = (*t10);
- mem_Allocator_free__anon_2698__4214(t11, t9);
+ mem_Allocator_free__anon_2159__4104(t11, t9);
  t7 = (*t1);
- t13 = (nav__3914_43 *)&t7->items;
+ t13 = (nav__3926_43 *)&t7->items;
  t14 = &t13->ptr;
  t15 = t12.ptr;
  (*t14) = t15;
@@ -5485,16 +5731,16 @@ static uint16_t array_list_ArrayListAligned_28u8_2cnull_29_ensureTotalCapacityPr
  return 0;
 }
 
-static nav__6230_39 mem_Allocator_remap__anon_3940__6230(struct mem_Allocator__565 const a0, nav__6230_39 const a1, uintptr_t const a2) {
+static nav__7158_39 mem_Allocator_remap__anon_4029__7158(struct mem_Allocator__565 const a0, nav__7158_39 const a1, uintptr_t const a2) {
  struct mem_Allocator__565 const *t1;
- nav__6230_39 const *t3;
+ nav__7158_39 const *t3;
  uint64_t t4;
  struct mem_Allocator__565 t6;
  struct mem_Allocator__565 t0;
  struct mem_Allocator__565 t15;
- nav__6230_39 t7;
- nav__6230_39 t10;
- nav__6230_39 t2;
+ nav__7158_39 t7;
+ nav__7158_39 t10;
+ nav__7158_39 t2;
  uint8_t *t8;
  uint8_t *t20;
  uint8_t *t21;
@@ -5502,23 +5748,23 @@ static nav__6230_39 mem_Allocator_remap__anon_3940__6230(struct mem_Allocator__5
  void *t9;
  uintptr_t t11;
  uintptr_t t13;
- nav__6230_50 t12;
+ nav__7158_50 t12;
  struct mem_Allocator_VTable__568 const *const *t16;
  struct mem_Allocator_VTable__568 const *t17;
- uint8_t *(*const *t18)(void *, nav__6230_39, uint8_t, uintptr_t, uintptr_t);
- uint8_t *(*t19)(void *, nav__6230_39, uint8_t, uintptr_t, uintptr_t);
+ uint8_t *(*const *t18)(void *, nav__7158_39, uint8_t, uintptr_t, uintptr_t);
+ uint8_t *(*t19)(void *, nav__7158_39, uint8_t, uintptr_t, uintptr_t);
  uint8_t *const *t23;
  bool t5;
  uint8_t t14;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
  t2 = a1;
- t3 = (nav__6230_39 const *)&t2;
+ t3 = (nav__7158_39 const *)&t2;
  t4 = a2;
  t5 = t4 == UINT64_C(0);
  if (t5) {
   t6 = (*t1);
-  mem_Allocator_free__anon_2698__4214(t6, a1);
+  mem_Allocator_free__anon_2159__4104(t6, a1);
   t7 = (*t3);
   t8 = t7.ptr;
   t8 = (uint8_t *)(((uintptr_t)t8) + ((uintptr_t)0ul*sizeof(uint8_t)));
@@ -5535,30 +5781,30 @@ static nav__6230_39 mem_Allocator_remap__anon_3940__6230(struct mem_Allocator__5
  t4 = t11;
  t5 = t4 == UINT64_C(0);
  if (t5) {
-  return (nav__6230_39){NULL,(uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  return (nav__7158_39){NULL,(uintptr_t)0xaaaaaaaaaaaaaaaaul};
  }
  goto zig_block_1;
 
  zig_block_1:;
- t10 = mem_sliceAsBytes__anon_2993__4350(a1);
- t12 = math_mul__anon_3381__6049((uintptr_t)1ul, a2);
+ t10 = mem_sliceAsBytes__anon_2966__5249(a1);
+ t12 = math_mul__anon_3472__6977((uintptr_t)1ul, a2);
  t5 = t12.error == UINT16_C(0);
  if (t5) {
   t13 = t12.payload;
   t11 = t13;
   goto zig_block_2;
  }
- return (nav__6230_39){NULL,(uintptr_t)0xaaaaaaaaaaaaaaaaul};
+ return (nav__7158_39){NULL,(uintptr_t)0xaaaaaaaaaaaaaaaaul};
 
  zig_block_2:;
  t6 = (*t1);
- t14 = mem_Alignment_fromByteUnits__1045((uintptr_t)1ul);
+ t14 = mem_Alignment_fromByteUnits__1046((uintptr_t)1ul);
  t13 = (uintptr_t)zig_return_address();
  t15 = t6;
  t1 = (struct mem_Allocator__565 const *)&t15;
  t16 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
  t17 = (*t16);
- t18 = (uint8_t *(*const *)(void *, nav__6230_39, uint8_t, uintptr_t, uintptr_t))&t17->remap;
+ t18 = (uint8_t *(*const *)(void *, nav__7158_39, uint8_t, uintptr_t, uintptr_t))&t17->remap;
  t19 = (*t18);
  t9 = t6.ptr;
  t20 = t19(t9, t10, t14, t11, t13);
@@ -5568,7 +5814,7 @@ static nav__6230_39 mem_Allocator_remap__anon_3940__6230(struct mem_Allocator__5
   t8 = t21;
   goto zig_block_3;
  }
- return (nav__6230_39){NULL,(uintptr_t)0xaaaaaaaaaaaaaaaaul};
+ return (nav__7158_39){NULL,(uintptr_t)0xaaaaaaaaaaaaaaaaul};
 
  zig_block_3:;
  t22 = t8;
@@ -5577,25 +5823,25 @@ static nav__6230_39 mem_Allocator_remap__anon_3940__6230(struct mem_Allocator__5
  t8 = (uint8_t *)(((uintptr_t)t8) + ((uintptr_t)0ul*sizeof(uint8_t)));
  t10.ptr = t8;
  t10.len = t11;
- memcpy(&t7, &t10, sizeof(nav__6230_39));
- t7 = mem_bytesAsSlice__anon_3960__6232(t7);
+ memcpy(&t7, &t10, sizeof(nav__7158_39));
+ t7 = mem_bytesAsSlice__anon_4049__7160(t7);
  t10 = t7;
  return t10;
 }
 
-static nav__6231_40 mem_Allocator_alignedAlloc__anon_3945__6231(struct mem_Allocator__565 const a0, uintptr_t const a1) {
+static nav__7159_40 mem_Allocator_alignedAlloc__anon_4034__7159(struct mem_Allocator__565 const a0, uintptr_t const a1) {
  struct mem_Allocator__565 const *t1;
  struct mem_Allocator__565 t2;
  struct mem_Allocator__565 t0;
  struct mem_Allocator__565 t5;
  uintptr_t t3;
- nav__6231_40 t4;
- nav__6231_40 t8;
- nav__6231_51 t6;
+ nav__7159_40 t4;
+ nav__7159_40 t8;
+ nav__7159_51 t6;
  uint8_t *t9;
  uint8_t *t10;
  uint8_t *const *t11;
- nav__6231_39 t12;
+ nav__7159_39 t12;
  uint16_t t7;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
@@ -5604,10 +5850,10 @@ static nav__6231_40 mem_Allocator_alignedAlloc__anon_3945__6231(struct mem_Alloc
  t5 = t2;
  t1 = (struct mem_Allocator__565 const *)&t5;
  t2 = (*t1);
- t6 = mem_Allocator_allocWithSizeAndAlignment__anon_2874__4321(t2, a1, t3);
+ t6 = mem_Allocator_allocWithSizeAndAlignment__anon_2953__5248(t2, a1, t3);
  if (t6.error) {
   t7 = t6.error;
-  t8.payload = (nav__6231_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t8.payload = (nav__7159_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t8.error = t7;
   t4 = t8;
   goto zig_block_0;
@@ -5628,13 +5874,13 @@ static nav__6231_40 mem_Allocator_alignedAlloc__anon_3945__6231(struct mem_Alloc
  return t4;
 }
 
-static nav__6232_39 mem_bytesAsSlice__anon_3960__6232(nav__6232_39 const a0) {
+static nav__7160_39 mem_bytesAsSlice__anon_4049__7160(nav__7160_39 const a0) {
  uintptr_t t0;
  uint64_t t1;
  uint8_t *t4;
  uint8_t *t5;
  uint8_t *const *t6;
- nav__6232_39 t7;
+ nav__7160_39 t7;
  bool t2;
  bool t3;
  t0 = a0.len;
@@ -5649,7 +5895,7 @@ static nav__6232_39 mem_bytesAsSlice__anon_3960__6232(nav__6232_39 const a0) {
 
  zig_block_1:;
  if (t3) {
-  return (nav__6232_39){(uint8_t *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
+  return (nav__7160_39){(uint8_t *)((void const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),(uintptr_t)0ul};
  }
  goto zig_block_0;
 
@@ -5666,7 +5912,7 @@ static nav__6232_39 mem_bytesAsSlice__anon_3960__6232(nav__6232_39 const a0) {
  return t7;
 }
 
-void c_instrument_hooks_deinit__239(struct instruments_root_InstrumentHooks__547 *const a0) {
+void c_instrument_hooks_deinit__240(struct instruments_root_InstrumentHooks__547 *const a0) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t4;
  struct instruments_root_InstrumentHooks__547 *t2;
@@ -5693,7 +5939,7 @@ void c_instrument_hooks_deinit__239(struct instruments_root_InstrumentHooks__547
    case UINT8_C(1): {
     t4 = (*t3);
     t8 = (struct instruments_perf_PerfInstrument__559 *)&t4->payload.perf;
-    instruments_perf_PerfInstrument_deinit__751(t8);
+    instruments_perf_PerfInstrument_deinit__752(t8);
     goto zig_block_1;
    }
    case UINT8_C(2): {
@@ -5703,7 +5949,7 @@ void c_instrument_hooks_deinit__239(struct instruments_root_InstrumentHooks__547
   }
 
   zig_block_1:;
-  mem_Allocator_destroy__anon_3975__6233((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3562)}, t1);
+  mem_Allocator_destroy__anon_2777__4228((struct mem_Allocator__565){((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3565)}, t1);
   goto zig_block_0;
  }
  goto zig_block_0;
@@ -5712,102 +5958,7 @@ void c_instrument_hooks_deinit__239(struct instruments_root_InstrumentHooks__547
  return;
 }
 
-static void instruments_perf_PerfInstrument_deinit__751(struct instruments_perf_PerfInstrument__559 *const a0) {
- struct instruments_perf_PerfInstrument__559 *const *t1;
- struct instruments_perf_PerfInstrument__559 *t2;
- struct instruments_perf_PerfInstrument__559 *t0;
- struct fifo_UnixPipe_Writer__600 *t3;
- struct fifo_UnixPipe_Reader__602 *t4;
- t0 = a0;
- t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
- t2 = (*t1);
- t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
- fifo_UnixPipe_Writer_deinit__1078(t3);
- t2 = (*t1);
- t4 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- fifo_UnixPipe_Reader_deinit__1085(t4);
- return;
-}
-
-static void mem_Allocator_destroy__anon_3975__6233(struct mem_Allocator__565 const a0, struct instruments_root_InstrumentHooks__547 *const a1) {
- struct mem_Allocator__565 const *t1;
- uint8_t *t2;
- uint8_t *t3;
- uint8_t *const *t4;
- struct mem_Allocator__565 t5;
- struct mem_Allocator__565 t0;
- struct mem_Allocator__565 t10;
- uint8_t (*t6)[72];
- nav__6233_52 t7;
- uintptr_t t9;
- struct mem_Allocator_VTable__568 const *const *t11;
- struct mem_Allocator_VTable__568 const *t12;
- void (*const *t13)(void *, nav__6233_52, uint8_t, uintptr_t);
- void (*t14)(void *, nav__6233_52, uint8_t, uintptr_t);
- void *t15;
- uint8_t t8;
- t0 = a0;
- t1 = (struct mem_Allocator__565 const *)&t0;
- t2 = (uint8_t *)a1;
- t3 = t2;
- t4 = (uint8_t *const *)&t3;
- t5 = (*t1);
- t2 = (*t4);
- t2 = (uint8_t *)(((uintptr_t)t2) + ((uintptr_t)0ul*sizeof(uint8_t)));
- t6 = (uint8_t (*)[72])t2;
- t7.ptr = &(*t6)[(uintptr_t)0ul];
- t7.len = (uintptr_t)72ul;
- t8 = mem_Alignment_fromByteUnits__1045((uintptr_t)8ul);
- t9 = (uintptr_t)zig_return_address();
- t10 = t5;
- t1 = (struct mem_Allocator__565 const *)&t10;
- t11 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
- t12 = (*t11);
- t13 = (void (*const *)(void *, nav__6233_52, uint8_t, uintptr_t))&t12->free;
- t14 = (*t13);
- t15 = t5.ptr;
- t14(t15, t7, t8, t9);
- return;
-}
-
-static void fifo_UnixPipe_Writer_deinit__1078(struct fifo_UnixPipe_Writer__600 *const a0) {
- struct fifo_UnixPipe_Writer__600 *const *t1;
- struct fifo_UnixPipe_Writer__600 *t2;
- struct fifo_UnixPipe_Writer__600 *t0;
- struct fs_File__608 *t3;
- struct fs_File__608 t4;
- t0 = a0;
- t1 = (struct fifo_UnixPipe_Writer__600 *const *)&t0;
- t2 = (*t1);
- t3 = (struct fs_File__608 *)&t2->file;
- t4 = (*t3);
- fs_File_close__1176(t4);
- return;
-}
-
-static void fifo_UnixPipe_Reader_deinit__1085(struct fifo_UnixPipe_Reader__602 *const a0) {
- struct fifo_UnixPipe_Reader__602 *const *t1;
- struct fifo_UnixPipe_Reader__602 *t2;
- struct fifo_UnixPipe_Reader__602 *t0;
- struct fs_File__608 *t3;
- struct fs_File__608 t4;
- t0 = a0;
- t1 = (struct fifo_UnixPipe_Reader__602 *const *)&t0;
- t2 = (*t1);
- t3 = (struct fs_File__608 *)&t2->file;
- t4 = (*t3);
- fs_File_close__1176(t4);
- return;
-}
-
-static void fs_File_close__1176(struct fs_File__608 const a0) {
- int32_t t0;
- t0 = a0.handle;
- posix_close__1419(t0);
- return;
-}
-
-bool c_instrument_hooks_is_instrumented__240(struct instruments_root_InstrumentHooks__547 *const a0) {
+bool c_instrument_hooks_is_instrumented__241(struct instruments_root_InstrumentHooks__547 *const a0) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t2;
  struct instruments_root_InstrumentHooks__547 *const *t3;
@@ -5836,7 +5987,7 @@ bool c_instrument_hooks_is_instrumented__240(struct instruments_root_InstrumentH
    case UINT8_C(1): {
     t8 = t4.payload.perf;
     t9 = t8;
-    t7 = instruments_perf_PerfInstrument_is_instrumented__753(&t9);
+    t7 = instruments_perf_PerfInstrument_is_instrumented__754(&t9);
     t0 = t7;
     goto zig_block_1;
    }
@@ -5860,7 +6011,7 @@ bool c_instrument_hooks_is_instrumented__240(struct instruments_root_InstrumentH
  return false;
 }
 
-static zig_cold uint16_t instruments_perf_PerfInstrument_start_benchmark__754(struct instruments_perf_PerfInstrument__559 *const a0) {
+static zig_cold uint16_t instruments_perf_PerfInstrument_start_benchmark__755(struct instruments_perf_PerfInstrument__559 *const a0) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
@@ -5871,20 +6022,20 @@ static zig_cold uint16_t instruments_perf_PerfInstrument_start_benchmark__754(st
  t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
  t2 = (*t1);
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
- t4 = fifo_UnixPipe_Writer_sendCmd__1077(t3, (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(1)});
+ t4 = fifo_UnixPipe_Writer_sendCmd__1080(t3, (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(1)});
  if (t4) {
   return t4;
  }
  t2 = (*t1);
  t5 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t4 = fifo_UnixPipe_Reader_waitForAck__1084(t5, (nav__754_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t4 = fifo_UnixPipe_Reader_waitForAck__1087(t5, (nav__755_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t4) {
   return t4;
  }
  return 0;
 }
 
-uint8_t c_instrument_hooks_start_benchmark__241(struct instruments_root_InstrumentHooks__547 *const a0) {
+uint8_t c_instrument_hooks_start_benchmark__242(struct instruments_root_InstrumentHooks__547 *const a0) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t2;
  struct instruments_root_InstrumentHooks__547 *t5;
@@ -5910,7 +6061,7 @@ uint8_t c_instrument_hooks_start_benchmark__241(struct instruments_root_Instrume
   if (t0) {
    t1 = (*t3);
    t8 = (struct instruments_perf_PerfInstrument__559 *)&t1->payload.perf;
-   t9 = instruments_perf_PerfInstrument_start_benchmark__754(t8);
+   t9 = instruments_perf_PerfInstrument_start_benchmark__755(t8);
    memcpy(&t10, &t9, sizeof(uint16_t));
    t4 = t10;
    goto zig_block_2;
@@ -5919,7 +6070,7 @@ uint8_t c_instrument_hooks_start_benchmark__241(struct instruments_root_Instrume
   t7 = t6.tag;
   t0 = t7 == UINT8_C(0);
   if (t0) {
-   t0 = features_is_feature_enabled__325(UINT64_C(0));
+   t0 = features_is_feature_enabled__326(UINT64_C(0));
    t0 = !t0;
    if (t0) {
     callgrind_zero_stats();
@@ -5958,19 +6109,19 @@ uint8_t c_instrument_hooks_start_benchmark__241(struct instruments_root_Instrume
  return UINT8_C(0);
 }
 
-static bool features_is_feature_enabled__325(uint64_t const a0) {
+static bool features_is_feature_enabled__326(uint64_t const a0) {
  uint64_t t0;
  uint64_t t1;
  uintptr_t t2;
  bool t3;
- t0 = (*&features_features__323);
+ t0 = (*&features_features__324);
  t1 = a0;
  t2 = t1;
- t3 = bit_set_IntegerBitSet_2864_29_isSet__360(t0, t2);
+ t3 = bit_set_IntegerBitSet_2864_29_isSet__361(t0, t2);
  return t3;
 }
 
-static bool bit_set_IntegerBitSet_2864_29_isSet__360(uint64_t const a0, uintptr_t const a1) {
+static bool bit_set_IntegerBitSet_2864_29_isSet__361(uint64_t const a0, uintptr_t const a1) {
  uint64_t t0;
  uint64_t t2;
  bool t1;
@@ -5978,13 +6129,13 @@ static bool bit_set_IntegerBitSet_2864_29_isSet__360(uint64_t const a0, uintptr_
  t1 = t0 < UINT64_C(64);
  debug_assert__180(t1);
  t0 = zig_wrap_u64((uint64_t)a0, UINT8_C(64));
- t2 = bit_set_IntegerBitSet_2864_29_maskBit__384(a1);
+ t2 = bit_set_IntegerBitSet_2864_29_maskBit__385(a1);
  t2 = t0 & t2;
  t1 = t2 != UINT64_C(0);
  return t1;
 }
 
-static zig_cold uint16_t instruments_perf_PerfInstrument_stop_benchmark__755(struct instruments_perf_PerfInstrument__559 *const a0) {
+static zig_cold uint16_t instruments_perf_PerfInstrument_stop_benchmark__756(struct instruments_perf_PerfInstrument__559 *const a0) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
@@ -5995,20 +6146,20 @@ static zig_cold uint16_t instruments_perf_PerfInstrument_stop_benchmark__755(str
  t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
  t2 = (*t1);
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
- t4 = fifo_UnixPipe_Writer_sendCmd__1077(t3, (struct shared_Command__1935){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(2)});
+ t4 = fifo_UnixPipe_Writer_sendCmd__1080(t3, (struct shared_Command__1946){{{{(uint8_t const *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},UINT32_C(0xaaaaaaaa)}},UINT8_C(2)});
  if (t4) {
   return t4;
  }
  t2 = (*t1);
  t5 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t4 = fifo_UnixPipe_Reader_waitForAck__1084(t5, (nav__755_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t4 = fifo_UnixPipe_Reader_waitForAck__1087(t5, (nav__756_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t4) {
   return t4;
  }
  return 0;
 }
 
-uint8_t c_instrument_hooks_stop_benchmark__242(struct instruments_root_InstrumentHooks__547 *const a0) {
+uint8_t c_instrument_hooks_stop_benchmark__243(struct instruments_root_InstrumentHooks__547 *const a0) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t2;
  struct instruments_root_InstrumentHooks__547 *t5;
@@ -6032,7 +6183,7 @@ uint8_t c_instrument_hooks_stop_benchmark__242(struct instruments_root_Instrumen
   t7 = t6.tag;
   t0 = t7 == UINT8_C(0);
   if (t0) {
-   t0 = features_is_feature_enabled__325(UINT64_C(0));
+   t0 = features_is_feature_enabled__326(UINT64_C(0));
    t0 = !t0;
    if (t0) {
     callgrind_stop_instrumentation();
@@ -6050,7 +6201,7 @@ uint8_t c_instrument_hooks_stop_benchmark__242(struct instruments_root_Instrumen
   if (t0) {
    t1 = (*t3);
    t8 = (struct instruments_perf_PerfInstrument__559 *)&t1->payload.perf;
-   t9 = instruments_perf_PerfInstrument_stop_benchmark__755(t8);
+   t9 = instruments_perf_PerfInstrument_stop_benchmark__756(t8);
    memcpy(&t10, &t9, sizeof(uint16_t));
    t4 = t10;
    goto zig_block_2;
@@ -6081,41 +6232,41 @@ uint8_t c_instrument_hooks_stop_benchmark__242(struct instruments_root_Instrumen
  return UINT8_C(0);
 }
 
-static uint16_t instruments_perf_PerfInstrument_set_executed_benchmark__756(struct instruments_perf_PerfInstrument__559 *const a0, uint32_t const a1, uint8_t const *const a2) {
+static uint16_t instruments_perf_PerfInstrument_set_executed_benchmark__757(struct instruments_perf_PerfInstrument__559 *const a0, uint32_t const a1, uint8_t const *const a2) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
  struct fifo_UnixPipe_Writer__600 *t3;
- nav__756_56 t4;
- nav__756_56 t5;
- struct shared_Command__struct_1938__1938 t6;
- struct shared_Command__1935 t7;
+ nav__757_56 t4;
+ nav__757_56 t5;
+ struct shared_Command__struct_1949__1949 t6;
+ struct shared_Command__1946 t7;
  struct fifo_UnixPipe_Reader__602 *t9;
  uint16_t t8;
  t0 = a0;
  t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
  t2 = (*t1);
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
- t4 = mem_span__anon_4096__6238(a2);
- memcpy(&t5, &t4, sizeof(nav__756_56));
+ t4 = mem_span__anon_4156__7165(a2);
+ memcpy(&t5, &t4, sizeof(nav__757_56));
  t6.uri = t5;
  t6.pid = a1;
  t7.tag = UINT8_C(0);
  t7.payload.ExecutedBenchmark = t6;
- t8 = fifo_UnixPipe_Writer_sendCmd__1077(t3, t7);
+ t8 = fifo_UnixPipe_Writer_sendCmd__1080(t3, t7);
  if (t8) {
   return t8;
  }
  t2 = (*t1);
  t9 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t8 = fifo_UnixPipe_Reader_waitForAck__1084(t9, (nav__756_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t8 = fifo_UnixPipe_Reader_waitForAck__1087(t9, (nav__757_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t8) {
   return t8;
  }
  return 0;
 }
 
-uint8_t c_instrument_hooks_set_executed_benchmark__243(struct instruments_root_InstrumentHooks__547 *const a0, uint32_t const a1, uint8_t const *const a2) {
+uint8_t c_instrument_hooks_set_executed_benchmark__244(struct instruments_root_InstrumentHooks__547 *const a0, uint32_t const a1, uint8_t const *const a2) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t2;
  struct instruments_root_InstrumentHooks__547 *t5;
@@ -6146,7 +6297,7 @@ uint8_t c_instrument_hooks_set_executed_benchmark__243(struct instruments_root_I
    case UINT8_C(1): {
     t1 = (*t3);
     t9 = (struct instruments_perf_PerfInstrument__559 *)&t1->payload.perf;
-    t10 = instruments_perf_PerfInstrument_set_executed_benchmark__756(t9, a1, a2);
+    t10 = instruments_perf_PerfInstrument_set_executed_benchmark__757(t9, a1, a2);
     if (t10) {
      t4 = t10;
      goto zig_block_2;
@@ -6180,15 +6331,15 @@ uint8_t c_instrument_hooks_set_executed_benchmark__243(struct instruments_root_I
  return UINT8_C(0);
 }
 
-static nav__6238_39 mem_span__anon_4096__6238(uint8_t const *const a0) {
+static nav__7165_39 mem_span__anon_4156__7165(uint8_t const *const a0) {
  uint8_t const *const *t1;
  uintptr_t t2;
  uint8_t const *t3;
  uint8_t const *t0;
- nav__6238_39 t4;
+ nav__7165_39 t4;
  t0 = a0;
  t1 = (uint8_t const *const *)&t0;
- t2 = mem_len__anon_4105__6239(a0);
+ t2 = mem_len__anon_4165__7166(a0);
  t3 = (*t1);
  t3 = (uint8_t const *)(((uintptr_t)t3) + ((uintptr_t)0ul*sizeof(uint8_t)));
  t4.ptr = t3;
@@ -6196,18 +6347,18 @@ static nav__6238_39 mem_span__anon_4096__6238(uint8_t const *const a0) {
  return t4;
 }
 
-static uintptr_t mem_len__anon_4105__6239(uint8_t const *const a0) {
+static uintptr_t mem_len__anon_4165__7166(uint8_t const *const a0) {
  uint8_t const *t1;
  uintptr_t t2;
  bool t0;
  t0 = a0 != NULL;
  debug_assert__180(t0);
  t1 = (uint8_t const *)a0;
- t2 = mem_indexOfSentinel__anon_4113__6240(t1);
+ t2 = mem_indexOfSentinel__anon_4173__7167(t1);
  return t2;
 }
 
-static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
+static uintptr_t mem_indexOfSentinel__anon_4173__7167(uint8_t const *const a0) {
  static uint8_t const t11[32] = "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000";
  static uint8_t const t18[32] = "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000";
  uint8_t const *const *t1;
@@ -6224,13 +6375,13 @@ static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
  uint8_t t9[32];
  uint8_t t10[32];
  bool t12[32];
- nav__6240_45 t13;
- nav__6240_47 t14;
+ nav__7167_45 t13;
+ nav__7167_47 t14;
  uint8_t t15;
  t0 = a0;
  t1 = (uint8_t const *const *)&t0;
  t2 = (uintptr_t)0ul;
- t3 = math_isPowerOfTwo__anon_4124__6241();
+ t3 = math_isPowerOfTwo__anon_4184__7168();
  if (t3) {
   debug_assert__180(true);
   t4 = t2;
@@ -6256,8 +6407,8 @@ static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
    }
    if (t3) {
     t4 = t2;
-    memcpy(t13.array, t12, sizeof(nav__6240_45));
-    t14 = simd_firstTrue__anon_4336__6606(t13);
+    memcpy(t13.array, t12, sizeof(nav__7167_45));
+    t14 = simd_firstTrue__anon_4396__7533(t13);
     t15 = t14.payload;
     t6 = (uintptr_t)t15;
     t6 = t4 + t6;
@@ -6267,7 +6418,7 @@ static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
 
    zig_block_2:;
    t6 = t2;
-   t16 = mem_alignForward__anon_4339__6607(t4, (uintptr_t)32ul);
+   t16 = mem_alignForward__anon_4399__7534(t4, (uintptr_t)32ul);
    t4 = t16 - t4;
    t4 = t4 / (uintptr_t)1ul;
    t4 = t6 + t4;
@@ -6311,7 +6462,7 @@ static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
   t5 = (*t1);
   t5 = (uint8_t const *)&t5[t6];
   t6 = (uintptr_t)t5;
-  t3 = mem_isAligned__914(t6, (uintptr_t)32ul);
+  t3 = mem_isAligned__915(t6, (uintptr_t)32ul);
   debug_assert__180(t3);
   zig_loop_114:
   t6 = t2;
@@ -6329,8 +6480,8 @@ static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
   }
   if (t3) {
    t6 = t2;
-   memcpy(t13.array, t12, sizeof(nav__6240_45));
-   t14 = simd_firstTrue__anon_4336__6606(t13);
+   memcpy(t13.array, t12, sizeof(nav__7167_45));
+   t14 = simd_firstTrue__anon_4396__7533(t13);
    t15 = t14.payload;
    t4 = (uintptr_t)t15;
    t4 = t6 + t4;
@@ -6367,26 +6518,26 @@ static uintptr_t mem_indexOfSentinel__anon_4113__6240(uint8_t const *const a0) {
  return t16;
 }
 
-static bool math_isPowerOfTwo__anon_4124__6241(void) {
+static bool math_isPowerOfTwo__anon_4184__7168(void) {
  debug_assert__180(true);
  return true;
 }
 
-static nav__6606_38 simd_firstTrue__anon_4336__6606(nav__6606_40 const a0) {
+static nav__7533_38 simd_firstTrue__anon_4396__7533(nav__7533_40 const a0) {
  static uint8_t const t2[32] = {UINT8_C(0),UINT8_C(1),UINT8_C(2),UINT8_C(3),UINT8_C(4),UINT8_C(5),UINT8_C(6),UINT8_C(7),UINT8_C(8),UINT8_C(9),UINT8_C(10),UINT8_C(11),UINT8_C(12),UINT8_C(13),UINT8_C(14),UINT8_C(15),UINT8_C(16),UINT8_C(17),UINT8_C(18),UINT8_C(19),UINT8_C(20),UINT8_C(21),UINT8_C(22),UINT8_C(23),UINT8_C(24),UINT8_C(25),UINT8_C(26),UINT8_C(27),UINT8_C(28),UINT8_C(29),UINT8_C(30),UINT8_C(31)};
  static uint8_t const t3[32] = {UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31),UINT8_C(31)};
  uintptr_t t1;
  bool t0;
  uint8_t t4[32];
  uint8_t t5;
- nav__6606_38 t6;
+ nav__7533_38 t6;
  t0 = false;
  for (t1 = (uintptr_t)0ul; t1 < (uintptr_t)32ul; t1 += (uintptr_t)1ul) {
   t0 |= a0.array[t1];
  }
  t0 = !t0;
  if (t0) {
-  return (nav__6606_38){true,UINT8_C(0xa)};
+  return (nav__7533_38){true,UINT8_C(0xa)};
  }
  goto zig_block_0;
 
@@ -6403,35 +6554,35 @@ static nav__6606_38 simd_firstTrue__anon_4336__6606(nav__6606_40 const a0) {
  return t6;
 }
 
-static uintptr_t mem_alignForward__anon_4339__6607(uintptr_t const a0, uintptr_t const a1) {
+static uintptr_t mem_alignForward__anon_4399__7534(uintptr_t const a0, uintptr_t const a1) {
  uintptr_t t1;
  bool t0;
- t0 = mem_isValidAlignGeneric__anon_4397__6608(a1);
+ t0 = mem_isValidAlignGeneric__anon_4457__7535(a1);
  debug_assert__180(t0);
  t1 = a1 - (uintptr_t)1ul;
  t1 = a0 + t1;
- t1 = mem_alignBackward__anon_4398__6609(t1, a1);
+ t1 = mem_alignBackward__anon_4458__7536(t1, a1);
  return t1;
 }
 
-static bool mem_isAligned__914(uintptr_t const a0, uintptr_t const a1) {
+static bool mem_isAligned__915(uintptr_t const a0, uintptr_t const a1) {
  uint64_t t0;
  uint64_t t1;
  bool t2;
  t0 = a0;
  t1 = a1;
- t2 = mem_isAlignedGeneric__anon_4404__6610(t0, t1);
+ t2 = mem_isAlignedGeneric__anon_4464__7537(t0, t1);
  return t2;
 }
 
-static bool mem_isValidAlignGeneric__anon_4397__6608(uintptr_t const a0) {
+static bool mem_isValidAlignGeneric__anon_4457__7535(uintptr_t const a0) {
  uint64_t t0;
  bool t1;
  bool t2;
  t0 = a0;
  t1 = t0 > UINT64_C(0);
  if (t1) {
-  t1 = math_isPowerOfTwo__anon_3401__6051(a0);
+  t1 = math_isPowerOfTwo__anon_3486__6979(a0);
   t2 = t1;
   goto zig_block_0;
  }
@@ -6442,10 +6593,10 @@ static bool mem_isValidAlignGeneric__anon_4397__6608(uintptr_t const a0) {
  return t2;
 }
 
-static uintptr_t mem_alignBackward__anon_4398__6609(uintptr_t const a0, uintptr_t const a1) {
+static uintptr_t mem_alignBackward__anon_4458__7536(uintptr_t const a0, uintptr_t const a1) {
  uintptr_t t1;
  bool t0;
- t0 = mem_isValidAlignGeneric__anon_4397__6608(a1);
+ t0 = mem_isValidAlignGeneric__anon_4457__7535(a1);
  debug_assert__180(t0);
  t1 = a1 - (uintptr_t)1ul;
  t1 = zig_not_u64(t1, UINT8_C(64));
@@ -6453,18 +6604,18 @@ static uintptr_t mem_alignBackward__anon_4398__6609(uintptr_t const a0, uintptr_
  return t1;
 }
 
-static bool mem_isAlignedGeneric__anon_4404__6610(uint64_t const a0, uint64_t const a1) {
+static bool mem_isAlignedGeneric__anon_4464__7537(uint64_t const a0, uint64_t const a1) {
  uint64_t t0;
  bool t1;
- t0 = mem_alignBackward__anon_4406__6611(a0, a1);
+ t0 = mem_alignBackward__anon_4466__7538(a0, a1);
  t1 = t0 == a0;
  return t1;
 }
 
-static uint64_t mem_alignBackward__anon_4406__6611(uint64_t const a0, uint64_t const a1) {
+static uint64_t mem_alignBackward__anon_4466__7538(uint64_t const a0, uint64_t const a1) {
  uint64_t t1;
  bool t0;
- t0 = mem_isValidAlignGeneric__anon_4408__6612(a1);
+ t0 = mem_isValidAlignGeneric__anon_4468__7539(a1);
  debug_assert__180(t0);
  t1 = a1 - UINT64_C(1);
  t1 = zig_not_u64(t1, UINT8_C(64));
@@ -6472,12 +6623,12 @@ static uint64_t mem_alignBackward__anon_4406__6611(uint64_t const a0, uint64_t c
  return t1;
 }
 
-static bool mem_isValidAlignGeneric__anon_4408__6612(uint64_t const a0) {
+static bool mem_isValidAlignGeneric__anon_4468__7539(uint64_t const a0) {
  bool t0;
  bool t1;
  t0 = a0 > UINT64_C(0);
  if (t0) {
-  t0 = math_isPowerOfTwo__anon_4409__6613(a0);
+  t0 = math_isPowerOfTwo__anon_4469__7540(a0);
   t1 = t0;
   goto zig_block_0;
  }
@@ -6488,7 +6639,7 @@ static bool mem_isValidAlignGeneric__anon_4408__6612(uint64_t const a0) {
  return t1;
 }
 
-static bool math_isPowerOfTwo__anon_4409__6613(uint64_t const a0) {
+static bool math_isPowerOfTwo__anon_4469__7540(uint64_t const a0) {
  uint64_t t1;
  bool t0;
  t0 = a0 > UINT64_C(0);
@@ -6499,50 +6650,50 @@ static bool math_isPowerOfTwo__anon_4409__6613(uint64_t const a0) {
  return t0;
 }
 
-uint8_t c_instrument_hooks_executed_benchmark__244(struct instruments_root_InstrumentHooks__547 *const a0, uint32_t const a1, uint8_t const *const a2) {
+uint8_t c_instrument_hooks_executed_benchmark__245(struct instruments_root_InstrumentHooks__547 *const a0, uint32_t const a1, uint8_t const *const a2) {
  uint8_t t0;
- t0 = c_instrument_hooks_set_executed_benchmark__243(a0, a1, a2);
+ t0 = c_instrument_hooks_set_executed_benchmark__244(a0, a1, a2);
  return t0;
 }
 
-static uint16_t instruments_perf_PerfInstrument_set_integration__757(struct instruments_perf_PerfInstrument__559 *const a0, uint8_t const *const a1, uint8_t const *const a2) {
+static uint16_t instruments_perf_PerfInstrument_set_integration__758(struct instruments_perf_PerfInstrument__559 *const a0, uint8_t const *const a1, uint8_t const *const a2) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
  struct fifo_UnixPipe_Writer__600 *t3;
- nav__757_56 t4;
- nav__757_56 t5;
- nav__757_56 t6;
- struct shared_Command__struct_1939__1939 t7;
- struct shared_Command__1935 t8;
+ nav__758_56 t4;
+ nav__758_56 t5;
+ nav__758_56 t6;
+ struct shared_Command__struct_1950__1950 t7;
+ struct shared_Command__1946 t8;
  struct fifo_UnixPipe_Reader__602 *t10;
  uint16_t t9;
  t0 = a0;
  t1 = (struct instruments_perf_PerfInstrument__559 *const *)&t0;
  t2 = (*t1);
  t3 = (struct fifo_UnixPipe_Writer__600 *)&t2->writer;
- t4 = mem_span__anon_4096__6238(a1);
- t5 = mem_span__anon_4096__6238(a2);
- memcpy(&t6, &t4, sizeof(nav__757_56));
- memcpy(&t4, &t5, sizeof(nav__757_56));
+ t4 = mem_span__anon_4156__7165(a1);
+ t5 = mem_span__anon_4156__7165(a2);
+ memcpy(&t6, &t4, sizeof(nav__758_56));
+ memcpy(&t4, &t5, sizeof(nav__758_56));
  t7.name = t6;
  t7.version = t4;
  t8.tag = UINT8_C(5);
  t8.payload.SetIntegration = t7;
- t9 = fifo_UnixPipe_Writer_sendCmd__1077(t3, t8);
+ t9 = fifo_UnixPipe_Writer_sendCmd__1080(t3, t8);
  if (t9) {
   return t9;
  }
  t2 = (*t1);
  t10 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t9 = fifo_UnixPipe_Reader_waitForAck__1084(t10, (nav__757_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t9 = fifo_UnixPipe_Reader_waitForAck__1087(t10, (nav__758_71){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t9) {
   return t9;
  }
  return 0;
 }
 
-uint8_t c_instrument_hooks_set_integration__245(struct instruments_root_InstrumentHooks__547 *const a0, uint8_t const *const a1, uint8_t const *const a2) {
+uint8_t c_instrument_hooks_set_integration__246(struct instruments_root_InstrumentHooks__547 *const a0, uint8_t const *const a1, uint8_t const *const a2) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t2;
  struct instruments_root_InstrumentHooks__547 *t5;
@@ -6553,9 +6704,9 @@ uint8_t c_instrument_hooks_set_integration__245(struct instruments_root_Instrume
  struct instruments_valgrind_ValgrindInstrument__554 t11;
  struct instruments_valgrind_ValgrindInstrument__554 const *t12;
  struct mem_Allocator__565 t13;
- nav__245_62 t14;
- nav__245_67 t15;
- nav__245_65 t17;
+ nav__246_62 t14;
+ nav__246_67 t15;
+ nav__246_65 t17;
  uint8_t *t18;
  uint8_t const *t19;
  struct mem_Allocator__565 const *t20;
@@ -6585,7 +6736,7 @@ uint8_t c_instrument_hooks_set_integration__245(struct instruments_root_Instrume
     t13 = t9.allocator;
     t14.f0 = a1;
     t14.f1 = a2;
-    t15 = fmt_allocPrintZ__anon_4446__6614(t13, t14);
+    t15 = fmt_allocPrintZ__anon_4506__7541(t13, t14);
     if (t15.error) {
      t16 = t15.error;
      t10 = t16;
@@ -6597,7 +6748,7 @@ uint8_t c_instrument_hooks_set_integration__245(struct instruments_root_Instrume
     callgrind_dump_stats_at(t19);
     t20 = (struct mem_Allocator__565 const *)&t12->allocator;
     t13 = (*t20);
-    mem_Allocator_free__anon_4448__6615(t13, t17);
+    mem_Allocator_free__anon_4508__7542(t13, t17);
     t10 = 0;
     goto zig_block_4;
 
@@ -6612,7 +6763,7 @@ uint8_t c_instrument_hooks_set_integration__245(struct instruments_root_Instrume
    case UINT8_C(1): {
     t1 = (*t3);
     t21 = (struct instruments_perf_PerfInstrument__559 *)&t1->payload.perf;
-    t16 = instruments_perf_PerfInstrument_set_integration__757(t21, a1, a2);
+    t16 = instruments_perf_PerfInstrument_set_integration__758(t21, a1, a2);
     if (t16) {
      t4 = t16;
      goto zig_block_2;
@@ -6646,24 +6797,24 @@ uint8_t c_instrument_hooks_set_integration__245(struct instruments_root_Instrume
  return UINT8_C(0);
 }
 
-static nav__6614_40 fmt_allocPrintZ__anon_4446__6614(struct mem_Allocator__565 const a0, nav__6614_43 const a1) {
- nav__6614_40 t0;
- nav__6614_39 t2;
- nav__6614_39 t3;
- nav__6614_39 const *t4;
+static nav__7541_40 fmt_allocPrintZ__anon_4506__7541(struct mem_Allocator__565 const a0, nav__7541_43 const a1) {
+ nav__7541_40 t0;
+ nav__7541_39 t2;
+ nav__7541_39 t3;
+ nav__7541_39 const *t4;
  uintptr_t t5;
  uint8_t *t6;
  uint16_t t1;
- t0 = fmt_allocPrint__anon_4473__6616(a0, a1);
+ t0 = fmt_allocPrint__anon_4533__7543(a0, a1);
  if (t0.error) {
   t1 = t0.error;
-  t0.payload = (nav__6614_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t0.payload = (nav__7541_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t0.error = t1;
   return t0;
  }
  t2 = t0.payload;
  t3 = t2;
- t4 = (nav__6614_39 const *)&t3;
+ t4 = (nav__7541_39 const *)&t3;
  t5 = t2.len;
  t5 = t5 - (uintptr_t)1ul;
  t2 = (*t4);
@@ -6676,9 +6827,9 @@ static nav__6614_40 fmt_allocPrintZ__anon_4446__6614(struct mem_Allocator__565 c
  return t0;
 }
 
-static void mem_Allocator_free__anon_4448__6615(struct mem_Allocator__565 const a0, nav__6615_40 const a1) {
+static void mem_Allocator_free__anon_4508__7542(struct mem_Allocator__565 const a0, nav__7542_40 const a1) {
  struct mem_Allocator__565 const *t1;
- nav__6615_40 t2;
+ nav__7542_40 t2;
  uintptr_t t3;
  uint64_t t4;
  uint8_t *t6;
@@ -6690,14 +6841,14 @@ static void mem_Allocator_free__anon_4448__6615(struct mem_Allocator__565 const 
  struct mem_Allocator__565 t12;
  struct mem_Allocator_VTable__568 const *const *t13;
  struct mem_Allocator_VTable__568 const *t14;
- void (*const *t15)(void *, nav__6615_40, uint8_t, uintptr_t);
- void (*t16)(void *, nav__6615_40, uint8_t, uintptr_t);
+ void (*const *t15)(void *, nav__7542_40, uint8_t, uintptr_t);
+ void (*t16)(void *, nav__7542_40, uint8_t, uintptr_t);
  void *t17;
  bool t5;
  uint8_t t11;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
- t2 = mem_sliceAsBytes__anon_4480__6617(a1);
+ t2 = mem_sliceAsBytes__anon_4540__7544(a1);
  t3 = t2.len;
  t3 = t3 + (uintptr_t)1ul;
  t4 = t3;
@@ -6721,55 +6872,55 @@ static void mem_Allocator_free__anon_4448__6615(struct mem_Allocator__565 const 
  t7 = (uint8_t *)(((uintptr_t)t7) + ((uintptr_t)0ul*sizeof(uint8_t)));
  t2.ptr = t7;
  t2.len = t3;
- t11 = mem_Alignment_fromByteUnits__1045((uintptr_t)1ul);
+ t11 = mem_Alignment_fromByteUnits__1046((uintptr_t)1ul);
  t3 = (uintptr_t)zig_return_address();
  t12 = t10;
  t1 = (struct mem_Allocator__565 const *)&t12;
  t13 = (struct mem_Allocator_VTable__568 const *const *)&t1->vtable;
  t14 = (*t13);
- t15 = (void (*const *)(void *, nav__6615_40, uint8_t, uintptr_t))&t14->free;
+ t15 = (void (*const *)(void *, nav__7542_40, uint8_t, uintptr_t))&t14->free;
  t16 = (*t15);
  t17 = t10.ptr;
  t16(t17, t2, t11, t3);
  return;
 }
 
-static nav__6616_40 fmt_allocPrint__anon_4473__6616(struct mem_Allocator__565 const a0, nav__6616_43 const a1) {
+static nav__7543_40 fmt_allocPrint__anon_4533__7543(struct mem_Allocator__565 const a0, nav__7543_43 const a1) {
  struct mem_Allocator__565 const *t1;
  uintptr_t t2;
  uintptr_t t6;
  uint64_t t3;
- nav__6616_54 t4;
+ nav__7543_54 t4;
  struct mem_Allocator__565 t7;
  struct mem_Allocator__565 t0;
- nav__6616_40 t8;
- nav__6616_40 t11;
- nav__6616_39 t10;
+ nav__7543_40 t8;
+ nav__7543_40 t11;
+ nav__7543_39 t10;
  uint16_t t9;
  bool t5;
  t0 = a0;
  t1 = (struct mem_Allocator__565 const *)&t0;
- t3 = fmt_count__anon_4487__6618(a1);
- t4 = math_cast__anon_4489__6619(t3);
+ t3 = fmt_count__anon_4547__7545(a1);
+ t4 = math_cast__anon_4549__7546(t3);
  t5 = t4.is_null != true;
  if (t5) {
   t6 = t4.payload;
   t2 = t6;
   goto zig_block_0;
  }
- return (nav__6616_40){{(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},zig_error_OutOfMemory};
+ return (nav__7543_40){{(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},zig_error_OutOfMemory};
 
  zig_block_0:;
  t7 = (*t1);
- t8 = mem_Allocator_alloc__anon_2129__4091(t7, t2);
+ t8 = mem_Allocator_alloc__anon_2153__4103(t7, t2);
  if (t8.error) {
   t9 = t8.error;
-  t8.payload = (nav__6616_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
+  t8.payload = (nav__7543_39){(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul};
   t8.error = t9;
   return t8;
  }
  t10 = t8.payload;
- t8 = fmt_bufPrint__anon_4498__6620(t10, a1);
+ t8 = fmt_bufPrint__anon_4558__7547(t10, a1);
  t5 = t8.error == UINT16_C(0);
  if (t5) {
   t10 = t8.payload;
@@ -6790,14 +6941,14 @@ static nav__6616_40 fmt_allocPrint__anon_4473__6616(struct mem_Allocator__565 co
  return t11;
 }
 
-static nav__6617_39 mem_sliceAsBytes__anon_4480__6617(nav__6617_39 const a0) {
+static nav__7544_39 mem_sliceAsBytes__anon_4540__7544(nav__7544_39 const a0) {
  uintptr_t t0;
  uint64_t t1;
  uint8_t *t3;
  uint8_t *t4;
  uint8_t *t5;
  uint8_t *const *t6;
- nav__6617_39 t7;
+ nav__7544_39 t7;
  bool t2;
  t0 = a0.len;
  t1 = t0;
@@ -6820,75 +6971,75 @@ static nav__6617_39 mem_sliceAsBytes__anon_4480__6617(nav__6617_39 const a0) {
  return t7;
 }
 
-static uint16_t fmt_format__anon_4555__6659(struct io_Writer__3831 const a0, nav__6659_40 const a1) {
- struct io_Writer__3831 const *t1;
- struct io_Writer__3831 t2;
- struct io_Writer__3831 t0;
+static uint16_t fmt_format__anon_4615__7586(struct io_Writer__3920 const a0, nav__7586_40 const a1) {
+ struct io_Writer__3920 const *t1;
+ struct io_Writer__3920 t2;
+ struct io_Writer__3920 t0;
  uint8_t const *t4;
  uint16_t t3;
  t0 = a0;
- t1 = (struct io_Writer__3831 const *)&t0;
+ t1 = (struct io_Writer__3920 const *)&t0;
  t2 = (*t1);
- t3 = io_Writer_writeAll__6132(t2, (nav__6659_44){(uint8_t const *)&__anon_4607,(uintptr_t)10ul});
+ t3 = io_Writer_writeAll__7060(t2, (nav__7586_44){(uint8_t const *)&__anon_4667,(uintptr_t)10ul});
  if (t3) {
   return t3;
  }
  t4 = a1.f0;
- t3 = fmt_formatType__anon_4880__6827(t4, (struct fmt_FormatOptions__4866){{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},UINT32_C(32),UINT8_C(2)}, a0, (uintptr_t)3ul);
+ t3 = fmt_formatType__anon_4940__7754(t4, (struct fmt_FormatOptions__4926){{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},UINT32_C(32),UINT8_C(2)}, a0, (uintptr_t)3ul);
  if (t3) {
   return t3;
  }
  t2 = (*t1);
- t3 = io_Writer_writeAll__6132(t2, (nav__6659_44){(uint8_t const *)&__anon_4888,(uintptr_t)1ul});
+ t3 = io_Writer_writeAll__7060(t2, (nav__7586_44){(uint8_t const *)&__anon_4948,(uintptr_t)1ul});
  if (t3) {
   return t3;
  }
  t4 = a1.f1;
- t3 = fmt_formatType__anon_4880__6827(t4, (struct fmt_FormatOptions__4866){{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},UINT32_C(32),UINT8_C(2)}, a0, (uintptr_t)3ul);
+ t3 = fmt_formatType__anon_4940__7754(t4, (struct fmt_FormatOptions__4926){{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},{(uintptr_t)0xaaaaaaaaaaaaaaaaul,true},UINT32_C(32),UINT8_C(2)}, a0, (uintptr_t)3ul);
  if (t3) {
   return t3;
  }
  t2 = (*t1);
- t3 = io_Writer_writeAll__6132(t2, (nav__6659_44){(uint8_t const *)&__anon_4908,(uintptr_t)1ul});
+ t3 = io_Writer_writeAll__7060(t2, (nav__7586_44){(uint8_t const *)&__anon_4968,(uintptr_t)1ul});
  if (t3) {
   return t3;
  }
  return 0;
 }
 
-static uint64_t fmt_count__anon_4487__6618(nav__6618_39 const a0) {
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 t1;
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 t0;
- struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 t2;
- struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 t3;
- struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 const *t4;
- struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 const *t5;
- struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 const *const *t6;
+static uint64_t fmt_count__anon_4547__7545(nav__7545_39 const a0) {
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 t1;
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 t0;
+ struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 t2;
+ struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 t3;
+ struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 const *t4;
+ struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 const *t5;
+ struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 const *const *t6;
  void const **t8;
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const *t9;
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const *t9;
  void const *t10;
- nav__6618_53 (**t11)(void const *, nav__6618_54);
- struct io_Writer__3831 t12;
- struct io_Writer__3831 t7;
+ nav__7545_53 (**t11)(void const *, nav__7545_54);
+ struct io_Writer__3920 t12;
+ struct io_Writer__3920 t7;
  uint64_t t15;
  uint16_t t13;
  bool t14;
- t1 = io_counting_writer_countingWriter__anon_4519__6645();
+ t1 = io_counting_writer_countingWriter__anon_4579__7572();
  t0 = t1;
- t2 = io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_writer__6644(&t0);
+ t2 = io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_writer__7571(&t0);
  t3 = t2;
- t4 = (struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 const *)&t3;
+ t4 = (struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 const *)&t3;
  t5 = t4;
- t6 = (struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 const *const *)&t5;
+ t6 = (struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 const *const *)&t5;
  t8 = (void const **)&t7.context;
  t4 = (*t6);
- t9 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const *)&t4->context;
+ t9 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const *)&t4->context;
  t10 = (void const *)t9;
  (*t8) = t10;
- t11 = (nav__6618_53 (**)(void const *, nav__6618_54))&t7.writeFn;
- (*t11) = &io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWr__6658;
+ t11 = (nav__7545_53 (**)(void const *, nav__7545_54))&t7.writeFn;
+ (*t11) = &io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWr__7585;
  t12 = t7;
- t13 = fmt_format__anon_4555__6659(t12, a0);
+ t13 = fmt_format__anon_4615__7586(t12, a0);
  t14 = t13 == UINT16_C(0);
  if (t14) {
   goto zig_block_0;
@@ -6901,56 +7052,56 @@ static uint64_t fmt_count__anon_4487__6618(nav__6618_39 const a0) {
  return t15;
 }
 
-static nav__6619_38 math_cast__anon_4489__6619(uint64_t const a0) {
+static nav__7546_38 math_cast__anon_4549__7546(uint64_t const a0) {
  uintptr_t t0;
- nav__6619_38 t1;
+ nav__7546_38 t1;
  t0 = a0;
  t1.is_null = false;
  t1.payload = t0;
  return t1;
 }
 
-static nav__6620_40 fmt_bufPrint__anon_4498__6620(nav__6620_39 const a0, nav__6620_42 const a1) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 t1;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 t0;
- struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 t2;
- struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 t3;
- struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 const *t4;
- struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 const *t5;
- struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 const *const *t6;
+static nav__7547_40 fmt_bufPrint__anon_4558__7547(nav__7547_39 const a0, nav__7547_42 const a1) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 t1;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 t0;
+ struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 t2;
+ struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 t3;
+ struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 const *t4;
+ struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 const *t5;
+ struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 const *const *t6;
  void const **t8;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t9;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t9;
  void const *t10;
- nav__6620_57 (**t11)(void const *, nav__6620_58);
- struct io_Writer__3831 t12;
- struct io_Writer__3831 t7;
- nav__6620_39 t15;
- nav__6620_40 t16;
+ nav__7547_57 (**t11)(void const *, nav__7547_58);
+ struct io_Writer__3920 t12;
+ struct io_Writer__3920 t7;
+ nav__7547_39 t15;
+ nav__7547_40 t16;
  uint16_t t13;
  bool t14;
- t1 = io_fixed_buffer_stream_fixedBufferStream__anon_2151__4123(a0);
+ t1 = io_fixed_buffer_stream_fixedBufferStream__anon_2181__4136(a0);
  t0 = t1;
- t2 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_writer__4113(&t0);
+ t2 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_writer__4126(&t0);
  t3 = t2;
- t4 = (struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 const *)&t3;
+ t4 = (struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 const *)&t3;
  t5 = t4;
- t6 = (struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 const *const *)&t5;
+ t6 = (struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 const *const *)&t5;
  t8 = (void const **)&t7.context;
  t4 = (*t6);
- t9 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t4->context;
+ t9 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t4->context;
  t10 = (void const *)t9;
  (*t8) = t10;
- t11 = (nav__6620_57 (**)(void const *, nav__6620_58))&t7.writeFn;
- (*t11) = &io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write__6840;
+ t11 = (nav__7547_57 (**)(void const *, nav__7547_58))&t7.writeFn;
+ (*t11) = &io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write__7767;
  t12 = t7;
- t13 = fmt_format__anon_4555__6659(t12, a1);
+ t13 = fmt_format__anon_4615__7586(t12, a1);
  t14 = t13 == UINT16_C(0);
  if (t14) {
   goto zig_block_0;
  }
  switch (t13) {
   case zig_error_NoSpaceLeft: {
-   return (nav__6620_40){{(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},zig_error_NoSpaceLeft};
+   return (nav__7547_40){{(uint8_t *)(uintptr_t)0xaaaaaaaaaaaaaaaaul, (uintptr_t)0xaaaaaaaaaaaaaaaaul},zig_error_NoSpaceLeft};
   }
   default: {
    zig_unreachable();
@@ -6959,85 +7110,85 @@ static nav__6620_40 fmt_bufPrint__anon_4498__6620(nav__6620_39 const a0, nav__66
 
  zig_block_0:;
  t1 = t0;
- t15 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWritten__4121(t1);
+ t15 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWritten__4134(t1);
  t16.payload = t15;
  t16.error = UINT16_C(0);
  return t16;
 }
 
-static struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 io_counting_writer_countingWriter__anon_4519__6645(void) {
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 t0;
- t0 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516){UINT64_C(0)};
+static struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 io_counting_writer_countingWriter__anon_4579__7572(void) {
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 t0;
+ t0 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576){UINT64_C(0)};
  return t0;
 }
 
-static struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_writer__6644(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const a0) {
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 **t1;
- struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4536 t0;
- t1 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 **)&t0.context;
+static struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_writer__7571(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const a0) {
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 **t1;
+ struct io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_2cerror_7b_7d_2c_28function_20_27write_27_29_29__4596 t0;
+ t1 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 **)&t0.context;
  (*t1) = a0;
  return t0;
 }
 
-static nav__6658_38 io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWr__6658(void const *const a0, nav__6658_41 const a1) {
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const *t0;
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *t1;
- nav__6658_38 t2;
- nav__6658_38 t3;
- t0 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const *)a0;
+static nav__7585_38 io_GenericWriter_28_2aio_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWr__7585(void const *const a0, nav__7585_41 const a1) {
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const *t0;
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *t1;
+ nav__7585_38 t2;
+ nav__7585_38 t3;
+ t0 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const *)a0;
  t1 = (*t0);
- t2 = io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_write__6643(t1, a1);
- memcpy(&t3, &t2, sizeof(nav__6658_38));
+ t2 = io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_write__7570(t1, a1);
+ memcpy(&t3, &t2, sizeof(nav__7585_38));
  return t3;
 }
 
-static uint16_t fmt_formatType__anon_4880__6827(uint8_t const *const a0, struct fmt_FormatOptions__4866 const a1, struct io_Writer__3831 const a2, uintptr_t const a3) {
- nav__6827_47 t2;
- nav__6827_47 t3;
+static uint16_t fmt_formatType__anon_4940__7754(uint8_t const *const a0, struct fmt_FormatOptions__4926 const a1, struct io_Writer__3920 const a2, uintptr_t const a3) {
+ nav__7754_47 t2;
+ nav__7754_47 t3;
  uint8_t const *t0;
- struct io_Writer__3831 t1;
+ struct io_Writer__3920 t1;
  uint16_t t4;
  uint16_t t5;
  (void)a3;
  t0 = a0;
  t1 = a2;
- t2 = mem_span__anon_4096__6238(a0);
- memcpy(&t3, &t2, sizeof(nav__6827_47));
- t4 = fmt_formatBuf__anon_4980__6841(t3, a1, a2);
+ t2 = mem_span__anon_4156__7165(a0);
+ memcpy(&t3, &t2, sizeof(nav__7754_47));
+ t4 = fmt_formatBuf__anon_5040__7768(t3, a1, a2);
  memcpy(&t5, &t4, sizeof(uint16_t));
  return t5;
 }
 
-static struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_writer__4113(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const a0) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 **t1;
- struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4924 t0;
- t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 **)&t0.context;
+static struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_writer__4126(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const a0) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 **t1;
+ struct io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write_27_29_29__4984 t0;
+ t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 **)&t0.context;
  (*t1) = a0;
  return t0;
 }
 
-static nav__6840_38 io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write__6840(void const *const a0, nav__6840_41 const a1) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t0;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *t1;
- nav__6840_38 t2;
- nav__6840_38 t3;
- t0 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)a0;
+static nav__7767_38 io_GenericWriter_28_2aio_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_2cerror_7bNoSpaceLeft_7d_2c_28function_20_27write__7767(void const *const a0, nav__7767_41 const a1) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t0;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *t1;
+ nav__7767_38 t2;
+ nav__7767_38 t3;
+ t0 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)a0;
  t1 = (*t0);
- t2 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write__4116(t1, a1);
- memcpy(&t3, &t2, sizeof(nav__6840_38));
+ t2 = io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write__4129(t1, a1);
+ memcpy(&t3, &t2, sizeof(nav__7767_38));
  return t3;
 }
 
-static nav__4121_39 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWritten__4121(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 const a0) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 const *t1;
- nav__4121_39 const *t2;
+static nav__4134_39 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWritten__4134(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 const a0) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 const *t1;
+ nav__4134_39 const *t2;
  uintptr_t t3;
- nav__4121_39 t4;
+ nav__4134_39 t4;
  uint8_t *t5;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 t0;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 t0;
  t0 = a0;
- t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 const *)&t0;
- t2 = (nav__4121_39 const *)&t1->buffer;
+ t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 const *)&t0;
+ t2 = (nav__4134_39 const *)&t1->buffer;
  t3 = a0.pos;
  t4 = (*t2);
  t5 = t4.ptr;
@@ -7047,18 +7198,18 @@ static nav__4121_39 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_getWr
  return t4;
 }
 
-static nav__6643_38 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_write__6643(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const a0, nav__6643_42 const a1) {
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const *t1;
- nav__6643_38 t2;
+static nav__7570_38 io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29_write__7570(struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const a0, nav__7570_42 const a1) {
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const *t1;
+ nav__7570_38 t2;
  uintptr_t t3;
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *t4;
- struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *t0;
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *t4;
+ struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *t0;
  uint64_t *t5;
  uint64_t t6;
  uint64_t t7;
  t0 = a0;
- t1 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4516 *const *)&t0;
- t2 = io_dummyWrite__4026(a1);
+ t1 = (struct io_counting_writer_CountingWriter_28io_GenericWriter_28void_2cerror_7b_7d_2c_28function_20_27dummyWrite_27_29_29_29__4576 *const *)&t0;
+ t2 = io_dummyWrite__4038(a1);
  t3 = t2.payload;
  t4 = (*t1);
  t5 = (uint64_t *)&t4->bytes_written;
@@ -7071,23 +7222,23 @@ static nav__6643_38 io_counting_writer_CountingWriter_28io_GenericWriter_28void_
  return t2;
 }
 
-static nav__6671_38 unicode_utf8ByteSequenceLength__6671(uint8_t const a0) {
- nav__6671_38 t0;
+static nav__7598_38 unicode_utf8ByteSequenceLength__7598(uint8_t const a0) {
+ nav__7598_38 t0;
  switch (a0) {
   default: if ((a0 >= UINT8_C(0) && a0 <= UINT8_C(127))) {
-   t0 = (nav__6671_38){0,UINT8_C(1)};
+   t0 = (nav__7598_38){0,UINT8_C(1)};
    goto zig_block_0;
   }if ((a0 >= UINT8_C(192) && a0 <= UINT8_C(223))) {
-   t0 = (nav__6671_38){0,UINT8_C(2)};
+   t0 = (nav__7598_38){0,UINT8_C(2)};
    goto zig_block_0;
   }if ((a0 >= UINT8_C(224) && a0 <= UINT8_C(239))) {
-   t0 = (nav__6671_38){0,UINT8_C(3)};
+   t0 = (nav__7598_38){0,UINT8_C(3)};
    goto zig_block_0;
   }if ((a0 >= UINT8_C(240) && a0 <= UINT8_C(247))) {
-   t0 = (nav__6671_38){0,UINT8_C(4)};
+   t0 = (nav__7598_38){0,UINT8_C(4)};
    goto zig_block_0;
   }{
-   t0 = (nav__6671_38){zig_error_Utf8InvalidStartByte,UINT8_C(0x2)};
+   t0 = (nav__7598_38){zig_error_Utf8InvalidStartByte,UINT8_C(0x2)};
    goto zig_block_0;
   }
  }
@@ -7096,27 +7247,27 @@ static nav__6671_38 unicode_utf8ByteSequenceLength__6671(uint8_t const a0) {
  return t0;
 }
 
-static nav__6687_38 unicode_utf8CountCodepoints__6687(nav__6687_40 const a0) {
- nav__6687_40 const *t1;
+static nav__7614_38 unicode_utf8CountCodepoints__7614(nav__7614_40 const a0) {
+ nav__7614_40 const *t1;
  uintptr_t t4;
  uintptr_t t5;
  uintptr_t t2;
  uintptr_t t3;
  uint64_t t6;
  uint64_t t7;
- nav__6687_40 t9;
- nav__6687_40 t0;
+ nav__7614_40 t9;
+ nav__7614_40 t0;
  uint8_t const *t10;
  uint8_t const (*t11)[8];
- nav__6687_38 t16;
- nav__6687_50 t17;
- nav__6687_48 t14;
+ nav__7614_38 t16;
+ nav__7614_50 t17;
+ nav__7614_48 t14;
  uint16_t t15;
  bool t8;
  uint8_t t12[8];
  uint8_t t13;
  t0 = a0;
- t1 = (nav__6687_40 const *)&t0;
+ t1 = (nav__7614_40 const *)&t0;
  t2 = (uintptr_t)0ul;
  t3 = (uintptr_t)0ul;
  zig_loop_9:
@@ -7173,7 +7324,7 @@ static nav__6687_38 unicode_utf8CountCodepoints__6687(nav__6687_40 const a0) {
   if (t8) {
    t4 = t3;
    t13 = a0.ptr[t4];
-   t14 = unicode_utf8ByteSequenceLength__6671(t13);
+   t14 = unicode_utf8ByteSequenceLength__7598(t13);
    if (t14.error) {
     t15 = t14.error;
     t16.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
@@ -7189,7 +7340,7 @@ static nav__6687_38 unicode_utf8CountCodepoints__6687(nav__6687_40 const a0) {
    t7 = t4;
    t8 = t6 > t7;
    if (t8) {
-    return (nav__6687_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_TruncatedInput};
+    return (nav__7614_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_TruncatedInput};
    }
    goto zig_block_6;
 
@@ -7206,7 +7357,7 @@ static nav__6687_38 unicode_utf8CountCodepoints__6687(nav__6687_40 const a0) {
      t4 = (uintptr_t)t13;
      t9.ptr = t10;
      t9.len = t4;
-     t17 = unicode_utf8Decode__6677(t9);
+     t17 = unicode_utf8Decode__7604(t9);
      if (t17.error) {
       t15 = t17.error;
       t16.payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul;
@@ -7244,35 +7395,35 @@ static nav__6687_38 unicode_utf8CountCodepoints__6687(nav__6687_40 const a0) {
  return t16;
 }
 
-static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt_FormatOptions__4866 const a1, struct io_Writer__3831 const a2) {
- struct io_Writer__3831 const *t1;
- nav__6841_44 t2;
+static uint16_t fmt_formatBuf__anon_5040__7768(nav__7768_39 const a0, struct fmt_FormatOptions__4926 const a1, struct io_Writer__3920 const a2) {
+ struct io_Writer__3920 const *t1;
+ nav__7768_44 t2;
  uintptr_t t4;
  uintptr_t t5;
  uintptr_t t7;
- nav__6841_48 t6;
+ nav__7768_48 t6;
  uint64_t t8;
  uint64_t t9;
- struct io_Writer__3831 t10;
- struct io_Writer__3831 t0;
- nav__6841_57 t15;
- nav__6841_39 t17;
- nav__6841_39 t20;
+ struct io_Writer__3920 t10;
+ struct io_Writer__3920 t0;
+ nav__7768_57 t15;
+ nav__7768_39 t17;
+ nav__7768_39 t20;
  uint8_t *t19;
  uint32_t t14;
  uint16_t t11;
  uint16_t t12;
- nav__6841_60 t16;
+ nav__7768_60 t16;
  bool t3;
  uint8_t t18;
  uint8_t t13[4];
  t0 = a2;
- t1 = (struct io_Writer__3831 const *)&t0;
+ t1 = (struct io_Writer__3920 const *)&t0;
  t2 = a1.width;
  t3 = t2.is_null != true;
  if (t3) {
   t4 = t2.payload;
-  t6 = unicode_utf8CountCodepoints__6687(a0);
+  t6 = unicode_utf8CountCodepoints__7614(a0);
   t3 = t6.error == UINT16_C(0);
   if (t3) {
    t7 = t6.payload;
@@ -7300,7 +7451,7 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
   t3 = t9 == UINT64_C(0);
   if (t3) {
    t10 = (*t1);
-   t11 = io_Writer_writeAll__6132(t10, a0);
+   t11 = io_Writer_writeAll__7060(t10, a0);
    memcpy(&t12, &t11, sizeof(uint16_t));
    return t12;
   }
@@ -7310,7 +7461,7 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
   t14 = a1.fill;
   t15.ptr = &t13[(uintptr_t)0ul];
   t15.len = (uintptr_t)4ul;
-  t16 = unicode_utf8Encode__6672(t14, t15);
+  t16 = unicode_utf8Encode__7599(t14, t15);
   t3 = t16.error == UINT16_C(0);
   if (t3) {
    t18 = t16.payload;
@@ -7319,7 +7470,7 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
    t5 = (uintptr_t)t18;
    t15.ptr = t19;
    t15.len = t5;
-   memcpy(&t20, &t15, sizeof(nav__6841_39));
+   memcpy(&t20, &t15, sizeof(nav__7768_39));
    t17 = t20;
    goto zig_block_4;
 
@@ -7328,7 +7479,7 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
   switch (t12) {
    case zig_error_Utf8CannotEncodeSurrogateHalf:
    case zig_error_CodepointTooLarge: {
-    t17 = (nav__6841_39){(uint8_t const *)&__anon_5079,(uintptr_t)3ul};
+    t17 = (nav__7768_39){(uint8_t const *)&__anon_5138,(uintptr_t)3ul};
     goto zig_block_4;
    }
    default: zig_unreachable();
@@ -7339,12 +7490,12 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
   switch (t18) {
    case UINT8_C(0): {
     t10 = (*t1);
-    t12 = io_Writer_writeAll__6132(t10, a0);
+    t12 = io_Writer_writeAll__7060(t10, a0);
     if (t12) {
      return t12;
     }
     t10 = (*t1);
-    t12 = io_Writer_writeBytesNTimes__6136(t10, t17, t7);
+    t12 = io_Writer_writeBytesNTimes__7064(t10, t17, t7);
     if (t12) {
      return t12;
     }
@@ -7355,17 +7506,17 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
     t7 = t7 + (uintptr_t)1ul;
     t7 = t7 / (uintptr_t)2ul;
     t10 = (*t1);
-    t12 = io_Writer_writeBytesNTimes__6136(t10, t17, t5);
+    t12 = io_Writer_writeBytesNTimes__7064(t10, t17, t5);
     if (t12) {
      return t12;
     }
     t10 = (*t1);
-    t12 = io_Writer_writeAll__6132(t10, a0);
+    t12 = io_Writer_writeAll__7060(t10, a0);
     if (t12) {
      return t12;
     }
     t10 = (*t1);
-    t12 = io_Writer_writeBytesNTimes__6136(t10, t17, t7);
+    t12 = io_Writer_writeBytesNTimes__7064(t10, t17, t7);
     if (t12) {
      return t12;
     }
@@ -7373,12 +7524,12 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
    }
    case UINT8_C(2): {
     t10 = (*t1);
-    t12 = io_Writer_writeBytesNTimes__6136(t10, t17, t7);
+    t12 = io_Writer_writeBytesNTimes__7064(t10, t17, t7);
     if (t12) {
      return t12;
     }
     t10 = (*t1);
-    t12 = io_Writer_writeAll__6132(t10, a0);
+    t12 = io_Writer_writeAll__7060(t10, a0);
     if (t12) {
      return t12;
     }
@@ -7391,7 +7542,7 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
   goto zig_block_0;
  }
  t10 = (*t1);
- t12 = io_Writer_writeAll__6132(t10, a0);
+ t12 = io_Writer_writeAll__7060(t10, a0);
  if (t12) {
   return t12;
  }
@@ -7401,52 +7552,52 @@ static uint16_t fmt_formatBuf__anon_4980__6841(nav__6841_39 const a0, struct fmt
  return 0;
 }
 
-static nav__4116_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write__4116(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const a0, nav__4116_42 const a1) {
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *t1;
- nav__4116_42 const *t3;
+static nav__4129_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write__4129(struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const a0, nav__4129_42 const a1) {
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *t1;
+ nav__4129_42 const *t3;
  uintptr_t t4;
  uintptr_t t10;
  uint64_t t5;
  uint64_t t11;
  uintptr_t *t7;
- nav__4116_50 *t8;
- nav__4116_50 t9;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *t12;
- struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *t0;
+ nav__4129_50 *t8;
+ nav__4129_50 t9;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *t12;
+ struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *t0;
  uint8_t *t13;
- nav__4116_42 t14;
- nav__4116_42 t2;
+ nav__4129_42 t14;
+ nav__4129_42 t2;
  uint8_t const *t15;
- nav__4116_38 t16;
+ nav__4129_38 t16;
  bool t6;
  t0 = a0;
- t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2148 *const *)&t0;
+ t1 = (struct io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29__2178 *const *)&t0;
  t2 = a1;
- t3 = (nav__4116_42 const *)&t2;
+ t3 = (nav__4129_42 const *)&t2;
  t4 = a1.len;
  t5 = t4;
  t6 = t5 == UINT64_C(0);
  if (t6) {
-  return (nav__4116_38){(uintptr_t)0ul,0};
+  return (nav__4129_38){(uintptr_t)0ul,0};
  }
  goto zig_block_0;
 
  zig_block_0:;
  t7 = (uintptr_t *)&a0->pos;
  t4 = (*t7);
- t8 = (nav__4116_50 *)&a0->buffer;
+ t8 = (nav__4129_50 *)&a0->buffer;
  t9 = (*t8);
  t10 = t9.len;
  t5 = t4;
  t11 = t10;
  t6 = t5 >= t11;
  if (t6) {
-  return (nav__4116_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoSpaceLeft};
+  return (nav__4129_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoSpaceLeft};
  }
  goto zig_block_1;
 
  zig_block_1:;
- t8 = (nav__4116_50 *)&a0->buffer;
+ t8 = (nav__4129_50 *)&a0->buffer;
  t9 = (*t8);
  t10 = t9.len;
  t7 = (uintptr_t *)&a0->pos;
@@ -7456,7 +7607,7 @@ static nav__4116_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write
  t10 = (t4 < t10) ? t4 : t10;
  t11 = t10;
  t12 = (*t1);
- t8 = (nav__4116_50 *)&t12->buffer;
+ t8 = (nav__4129_50 *)&t12->buffer;
  t7 = (uintptr_t *)&a0->pos;
  t10 = (*t7);
  t9 = (*t8);
@@ -7481,7 +7632,7 @@ static nav__4116_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write
  (*t7) = t4;
  t6 = t11 == UINT64_C(0);
  if (t6) {
-  return (nav__4116_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoSpaceLeft};
+  return (nav__4129_38){(uintptr_t)0xaaaaaaaaaaaaaaaaul,zig_error_NoSpaceLeft};
  }
  goto zig_block_2;
 
@@ -7492,37 +7643,37 @@ static nav__4116_38 io_fixed_buffer_stream_FixedBufferStream_28_5b_5du8_29_write
  return t16;
 }
 
-static nav__4026_38 io_dummyWrite__4026(nav__4026_40 const a0) {
+static nav__4038_38 io_dummyWrite__4038(nav__4038_40 const a0) {
  uintptr_t t0;
- nav__4026_38 t1;
+ nav__4038_38 t1;
  t0 = a0.len;
  t1.payload = t0;
  t1.error = UINT16_C(0);
  return t1;
 }
 
-static nav__6677_38 unicode_utf8Decode__6677(nav__6677_40 const a0) {
- nav__6677_40 const *t1;
+static nav__7604_38 unicode_utf8Decode__7604(nav__7604_40 const a0) {
+ nav__7604_40 const *t1;
  uintptr_t t2;
- nav__6677_40 t7;
- nav__6677_40 t0;
+ nav__7604_40 t7;
+ nav__7604_40 t0;
  uint8_t const *t8;
  uint8_t const (*t9)[2];
  uint8_t const (*t13)[3];
  uint8_t const (*t16)[4];
- nav__6677_38 t3;
- nav__6677_38 t6;
- nav__6677_38 t12;
+ nav__7604_38 t3;
+ nav__7604_38 t6;
+ nav__7604_38 t12;
  uint32_t t5;
  uint8_t t4;
  uint8_t t10[2];
- nav__6677_48 t11;
+ nav__7604_48 t11;
  uint8_t t14[3];
- nav__6677_52 t15;
+ nav__7604_52 t15;
  uint8_t t17[4];
- nav__6677_56 t18;
+ nav__7604_56 t18;
  t0 = a0;
- t1 = (nav__6677_40 const *)&t0;
+ t1 = (nav__7604_40 const *)&t0;
  t2 = a0.len;
  switch (t2) {
   case (uintptr_t)1ul: {
@@ -7539,9 +7690,9 @@ static nav__6677_38 unicode_utf8Decode__6677(nav__6677_40 const a0) {
    t8 = (uint8_t const *)(((uintptr_t)t8) + ((uintptr_t)0ul*sizeof(uint8_t)));
    t9 = (uint8_t const (*)[2])t8;
    memcpy(t10, (const char *)t9, sizeof(uint8_t[2]));
-   memcpy(t11.array, t10, sizeof(nav__6677_48));
-   t6 = unicode_utf8Decode2__6679(t11);
-   memcpy(&t12, &t6, sizeof(nav__6677_38));
+   memcpy(t11.array, t10, sizeof(nav__7604_48));
+   t6 = unicode_utf8Decode2__7606(t11);
+   memcpy(&t12, &t6, sizeof(nav__7604_38));
    t3 = t12;
    goto zig_block_0;
   }
@@ -7551,9 +7702,9 @@ static nav__6677_38 unicode_utf8Decode__6677(nav__6677_40 const a0) {
    t8 = (uint8_t const *)(((uintptr_t)t8) + ((uintptr_t)0ul*sizeof(uint8_t)));
    t13 = (uint8_t const (*)[3])t8;
    memcpy(t14, (const char *)t13, sizeof(uint8_t[3]));
-   memcpy(t15.array, t14, sizeof(nav__6677_52));
-   t12 = unicode_utf8Decode3__6681(t15);
-   memcpy(&t6, &t12, sizeof(nav__6677_38));
+   memcpy(t15.array, t14, sizeof(nav__7604_52));
+   t12 = unicode_utf8Decode3__7608(t15);
+   memcpy(&t6, &t12, sizeof(nav__7604_38));
    t3 = t6;
    goto zig_block_0;
   }
@@ -7563,9 +7714,9 @@ static nav__6677_38 unicode_utf8Decode__6677(nav__6677_40 const a0) {
    t8 = (uint8_t const *)(((uintptr_t)t8) + ((uintptr_t)0ul*sizeof(uint8_t)));
    t16 = (uint8_t const (*)[4])t8;
    memcpy(t17, (const char *)t16, sizeof(uint8_t[4]));
-   memcpy(t18.array, t17, sizeof(nav__6677_56));
-   t12 = unicode_utf8Decode4__6685(t18);
-   memcpy(&t6, &t12, sizeof(nav__6677_38));
+   memcpy(t18.array, t17, sizeof(nav__7604_56));
+   t12 = unicode_utf8Decode4__7612(t18);
+   memcpy(&t6, &t12, sizeof(nav__7604_38));
    t3 = t6;
    goto zig_block_0;
   }
@@ -7578,56 +7729,56 @@ static nav__6677_38 unicode_utf8Decode__6677(nav__6677_40 const a0) {
  return t3;
 }
 
-static nav__6670_38 unicode_utf8CodepointSequenceLength__6670(uint32_t const a0) {
+static nav__7597_38 unicode_utf8CodepointSequenceLength__7597(uint32_t const a0) {
  bool t0;
  t0 = a0 < UINT32_C(128);
  if (t0) {
-  return (nav__6670_38){0,UINT8_C(1)};
+  return (nav__7597_38){0,UINT8_C(1)};
  }
  goto zig_block_0;
 
  zig_block_0:;
  t0 = a0 < UINT32_C(2048);
  if (t0) {
-  return (nav__6670_38){0,UINT8_C(2)};
+  return (nav__7597_38){0,UINT8_C(2)};
  }
  goto zig_block_1;
 
  zig_block_1:;
  t0 = a0 < UINT32_C(65536);
  if (t0) {
-  return (nav__6670_38){0,UINT8_C(3)};
+  return (nav__7597_38){0,UINT8_C(3)};
  }
  goto zig_block_2;
 
  zig_block_2:;
  t0 = a0 < UINT32_C(1114112);
  if (t0) {
-  return (nav__6670_38){0,UINT8_C(4)};
+  return (nav__7597_38){0,UINT8_C(4)};
  }
  goto zig_block_3;
 
  zig_block_3:;
- return (nav__6670_38){zig_error_CodepointTooLarge,UINT8_C(0x2)};
+ return (nav__7597_38){zig_error_CodepointTooLarge,UINT8_C(0x2)};
 }
 
-static nav__6842_38 unicode_utf8EncodeImpl__anon_5111__6842(uint32_t const a0, nav__6842_40 const a1) {
- nav__6842_40 const *t1;
+static nav__7769_38 unicode_utf8EncodeImpl__anon_5170__7769(uint32_t const a0, nav__7769_40 const a1) {
+ nav__7769_40 const *t1;
  uintptr_t t5;
  uint64_t t6;
  uint64_t t7;
- nav__6842_40 t9;
- nav__6842_40 t0;
+ nav__7769_40 t9;
+ nav__7769_40 t0;
  uint8_t *t10;
  uint32_t t12;
- nav__6842_38 t2;
+ nav__7769_38 t2;
  uint16_t t3;
  uint8_t t4;
  uint8_t t11;
  bool t8;
  t0 = a1;
- t1 = (nav__6842_40 const *)&t0;
- t2 = unicode_utf8CodepointSequenceLength__6670(a0);
+ t1 = (nav__7769_40 const *)&t0;
+ t2 = unicode_utf8CodepointSequenceLength__7597(a0);
  if (t2.error) {
   t3 = t2.error;
   t2.payload = UINT8_C(0x2);
@@ -7664,9 +7815,9 @@ static nav__6842_38 unicode_utf8EncodeImpl__anon_5111__6842(uint32_t const a0, n
    goto zig_block_0;
   }
   case UINT8_C(3): {
-   t8 = unicode_isSurrogateCodepoint__6750(a0);
+   t8 = unicode_isSurrogateCodepoint__7677(a0);
    if (t8) {
-    return (nav__6842_38){zig_error_Utf8CannotEncodeSurrogateHalf,UINT8_C(0x2)};
+    return (nav__7769_38){zig_error_Utf8CannotEncodeSurrogateHalf,UINT8_C(0x2)};
    }
    goto zig_block_1;
 
@@ -7732,26 +7883,26 @@ static nav__6842_38 unicode_utf8EncodeImpl__anon_5111__6842(uint32_t const a0, n
  return t2;
 }
 
-static nav__6672_38 unicode_utf8Encode__6672(uint32_t const a0, nav__6672_40 const a1) {
- nav__6672_38 t0;
- nav__6672_38 t1;
- t0 = unicode_utf8EncodeImpl__anon_5111__6842(a0, a1);
- memcpy(&t1, &t0, sizeof(nav__6672_38));
+static nav__7599_38 unicode_utf8Encode__7599(uint32_t const a0, nav__7599_40 const a1) {
+ nav__7599_38 t0;
+ nav__7599_38 t1;
+ t0 = unicode_utf8EncodeImpl__anon_5170__7769(a0, a1);
+ memcpy(&t1, &t0, sizeof(nav__7599_38));
  return t1;
 }
 
-static uint16_t io_Writer_writeBytesNTimes__6136(struct io_Writer__3831 const a0, nav__6136_40 const a1, uintptr_t const a2) {
- struct io_Writer__3831 const *t1;
+static uint16_t io_Writer_writeBytesNTimes__7064(struct io_Writer__3920 const a0, nav__7064_40 const a1, uintptr_t const a2) {
+ struct io_Writer__3920 const *t1;
  uintptr_t t3;
  uintptr_t t2;
  uint64_t t4;
  uint64_t t5;
- struct io_Writer__3831 t7;
- struct io_Writer__3831 t0;
+ struct io_Writer__3920 t7;
+ struct io_Writer__3920 t0;
  uint16_t t8;
  bool t6;
  t0 = a0;
- t1 = (struct io_Writer__3831 const *)&t0;
+ t1 = (struct io_Writer__3920 const *)&t0;
  t2 = (uintptr_t)0ul;
  zig_loop_9:
  t3 = t2;
@@ -7760,7 +7911,7 @@ static uint16_t io_Writer_writeBytesNTimes__6136(struct io_Writer__3831 const a0
  t6 = t4 < t5;
  if (t6) {
   t7 = (*t1);
-  t8 = io_Writer_writeAll__6132(t7, a1);
+  t8 = io_Writer_writeAll__7060(t7, a1);
   if (t8) {
    return t8;
   }
@@ -7778,11 +7929,11 @@ static uint16_t io_Writer_writeBytesNTimes__6136(struct io_Writer__3831 const a0
  return 0;
 }
 
-static nav__6679_38 unicode_utf8Decode2__6679(nav__6679_40 const a0) {
+static nav__7606_38 unicode_utf8Decode2__7606(nav__7606_40 const a0) {
  uint32_t t3;
  uint32_t t4;
  uint32_t t2;
- nav__6679_38 t5;
+ nav__7606_38 t5;
  uint8_t t0;
  bool t1;
  t0 = a0.array[(uintptr_t)0ul];
@@ -7797,7 +7948,7 @@ static nav__6679_38 unicode_utf8Decode2__6679(nav__6679_40 const a0) {
  t0 = t0 & UINT8_C(192);
  t1 = t0 != UINT8_C(128);
  if (t1) {
-  return (nav__6679_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
+  return (nav__7606_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
  }
  goto zig_block_0;
 
@@ -7814,7 +7965,7 @@ static nav__6679_38 unicode_utf8Decode2__6679(nav__6679_40 const a0) {
  t4 = t2;
  t1 = t4 < UINT32_C(128);
  if (t1) {
-  return (nav__6679_38){UINT32_C(0xaaaaa),zig_error_Utf8OverlongEncoding};
+  return (nav__7606_38){UINT32_C(0xaaaaa),zig_error_Utf8OverlongEncoding};
  }
  goto zig_block_1;
 
@@ -7825,15 +7976,15 @@ static nav__6679_38 unicode_utf8Decode2__6679(nav__6679_40 const a0) {
  return t5;
 }
 
-static nav__6681_38 unicode_utf8Decode3__6681(nav__6681_40 const a0) {
- nav__6681_38 t1;
+static nav__7608_38 unicode_utf8Decode3__7608(nav__7608_40 const a0) {
+ nav__7608_38 t1;
  uint32_t t3;
  uint16_t t2;
- nav__6681_40 t0;
+ nav__7608_40 t0;
  bool t4;
  bool t5;
- memcpy(t0.array, a0.array, sizeof(nav__6681_40));
- t1 = unicode_utf8Decode3AllowSurrogateHalf__6683(t0);
+ memcpy(t0.array, a0.array, sizeof(nav__7608_40));
+ t1 = unicode_utf8Decode3AllowSurrogateHalf__7610(t0);
  if (t1.error) {
   t2 = t1.error;
   t1.payload = UINT32_C(0xaaaaa);
@@ -7852,7 +8003,7 @@ static nav__6681_38 unicode_utf8Decode3__6681(nav__6681_40 const a0) {
 
  zig_block_1:;
  if (t5) {
-  return (nav__6681_38){UINT32_C(0xaaaaa),zig_error_Utf8EncodesSurrogateHalf};
+  return (nav__7608_38){UINT32_C(0xaaaaa),zig_error_Utf8EncodesSurrogateHalf};
  }
  goto zig_block_0;
 
@@ -7862,11 +8013,11 @@ static nav__6681_38 unicode_utf8Decode3__6681(nav__6681_40 const a0) {
  return t1;
 }
 
-static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
+static nav__7612_38 unicode_utf8Decode4__7612(nav__7612_40 const a0) {
  uint32_t t3;
  uint32_t t4;
  uint32_t t2;
- nav__6685_38 t5;
+ nav__7612_38 t5;
  uint8_t t0;
  bool t1;
  t0 = a0.array[(uintptr_t)0ul];
@@ -7881,7 +8032,7 @@ static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
  t0 = t0 & UINT8_C(192);
  t1 = t0 != UINT8_C(128);
  if (t1) {
-  return (nav__6685_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
+  return (nav__7612_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
  }
  goto zig_block_0;
 
@@ -7899,7 +8050,7 @@ static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
  t0 = t0 & UINT8_C(192);
  t1 = t0 != UINT8_C(128);
  if (t1) {
-  return (nav__6685_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
+  return (nav__7612_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
  }
  goto zig_block_1;
 
@@ -7917,7 +8068,7 @@ static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
  t0 = t0 & UINT8_C(192);
  t1 = t0 != UINT8_C(128);
  if (t1) {
-  return (nav__6685_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
+  return (nav__7612_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
  }
  goto zig_block_2;
 
@@ -7934,7 +8085,7 @@ static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
  t4 = t2;
  t1 = t4 < UINT32_C(65536);
  if (t1) {
-  return (nav__6685_38){UINT32_C(0xaaaaa),zig_error_Utf8OverlongEncoding};
+  return (nav__7612_38){UINT32_C(0xaaaaa),zig_error_Utf8OverlongEncoding};
  }
  goto zig_block_3;
 
@@ -7942,7 +8093,7 @@ static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
  t4 = t2;
  t1 = t4 > UINT32_C(1114111);
  if (t1) {
-  return (nav__6685_38){UINT32_C(0xaaaaa),zig_error_Utf8CodepointTooLarge};
+  return (nav__7612_38){UINT32_C(0xaaaaa),zig_error_Utf8CodepointTooLarge};
  }
  goto zig_block_4;
 
@@ -7953,7 +8104,7 @@ static nav__6685_38 unicode_utf8Decode4__6685(nav__6685_40 const a0) {
  return t5;
 }
 
-static bool unicode_isSurrogateCodepoint__6750(uint32_t const a0) {
+static bool unicode_isSurrogateCodepoint__7677(uint32_t const a0) {
  bool t0;
  switch (a0) {
   default: if ((a0 >= UINT32_C(55296) && a0 <= UINT32_C(57343))) {
@@ -7969,11 +8120,11 @@ static bool unicode_isSurrogateCodepoint__6750(uint32_t const a0) {
  return t0;
 }
 
-static nav__6683_38 unicode_utf8Decode3AllowSurrogateHalf__6683(nav__6683_40 const a0) {
+static nav__7610_38 unicode_utf8Decode3AllowSurrogateHalf__7610(nav__7610_40 const a0) {
  uint32_t t3;
  uint32_t t4;
  uint32_t t2;
- nav__6683_38 t5;
+ nav__7610_38 t5;
  uint8_t t0;
  bool t1;
  t0 = a0.array[(uintptr_t)0ul];
@@ -7988,7 +8139,7 @@ static nav__6683_38 unicode_utf8Decode3AllowSurrogateHalf__6683(nav__6683_40 con
  t0 = t0 & UINT8_C(192);
  t1 = t0 != UINT8_C(128);
  if (t1) {
-  return (nav__6683_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
+  return (nav__7610_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
  }
  goto zig_block_0;
 
@@ -8006,7 +8157,7 @@ static nav__6683_38 unicode_utf8Decode3AllowSurrogateHalf__6683(nav__6683_40 con
  t0 = t0 & UINT8_C(192);
  t1 = t0 != UINT8_C(128);
  if (t1) {
-  return (nav__6683_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
+  return (nav__7610_38){UINT32_C(0xaaaaa),zig_error_Utf8ExpectedContinuation};
  }
  goto zig_block_1;
 
@@ -8023,7 +8174,7 @@ static nav__6683_38 unicode_utf8Decode3AllowSurrogateHalf__6683(nav__6683_40 con
  t3 = t2;
  t1 = t3 < UINT32_C(2048);
  if (t1) {
-  return (nav__6683_38){UINT32_C(0xaaaaa),zig_error_Utf8OverlongEncoding};
+  return (nav__7610_38){UINT32_C(0xaaaaa),zig_error_Utf8OverlongEncoding};
  }
  goto zig_block_2;
 
@@ -8034,13 +8185,13 @@ static nav__6683_38 unicode_utf8Decode3AllowSurrogateHalf__6683(nav__6683_40 con
  return t5;
 }
 
-static uint16_t instruments_perf_PerfInstrument_add_marker__758(struct instruments_perf_PerfInstrument__559 *const a0, uint32_t const a1, struct shared_MarkerType__1942 const a2) {
+static uint16_t instruments_perf_PerfInstrument_add_marker__759(struct instruments_perf_PerfInstrument__559 *const a0, uint32_t const a1, struct shared_MarkerType__1953 const a2) {
  struct instruments_perf_PerfInstrument__559 *const *t1;
  struct instruments_perf_PerfInstrument__559 *t2;
  struct instruments_perf_PerfInstrument__559 *t0;
  struct fifo_UnixPipe_Writer__600 *t3;
- struct shared_Command__struct_1940__1940 t4;
- struct shared_Command__1935 t5;
+ struct shared_Command__struct_1951__1951 t4;
+ struct shared_Command__1946 t5;
  struct fifo_UnixPipe_Reader__602 *t7;
  uint16_t t6;
  t0 = a0;
@@ -8051,26 +8202,26 @@ static uint16_t instruments_perf_PerfInstrument_add_marker__758(struct instrumen
  t4.pid = a1;
  t5.tag = UINT8_C(7);
  t5.payload.AddMarker = t4;
- t6 = fifo_UnixPipe_Writer_sendCmd__1077(t3, t5);
+ t6 = fifo_UnixPipe_Writer_sendCmd__1080(t3, t5);
  if (t6) {
   return t6;
  }
  t2 = (*t1);
  t7 = (struct fifo_UnixPipe_Reader__602 *)&t2->reader;
- t6 = fifo_UnixPipe_Reader_waitForAck__1084(t7, (nav__758_72){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
+ t6 = fifo_UnixPipe_Reader_waitForAck__1087(t7, (nav__759_72){UINT64_C(0xaaaaaaaaaaaaaaaa),true});
  if (t6) {
   return t6;
  }
  return 0;
 }
 
-uint8_t c_instrument_hooks_add_marker__250(struct instruments_root_InstrumentHooks__547 *const a0, uint32_t const a1, uint8_t const a2, uint64_t const a3) {
+uint8_t c_instrument_hooks_add_marker__251(struct instruments_root_InstrumentHooks__547 *const a0, uint32_t const a1, uint8_t const a2, uint64_t const a3) {
  struct instruments_root_InstrumentHooks__547 *t1;
  struct instruments_root_InstrumentHooks__547 *t2;
  struct instruments_root_InstrumentHooks__547 *t7;
  struct instruments_root_InstrumentHooks__547 *const *t3;
- struct shared_MarkerType__1942 t4;
- struct shared_MarkerType__1942 t5;
+ struct shared_MarkerType__1953 t4;
+ struct shared_MarkerType__1953 t5;
  struct instruments_root_InstrumentHooks__547 t8;
  struct instruments_perf_PerfInstrument__559 *t10;
  uint16_t t6;
@@ -8123,7 +8274,7 @@ uint8_t c_instrument_hooks_add_marker__250(struct instruments_root_InstrumentHoo
   if (t0) {
    t1 = (*t3);
    t10 = (struct instruments_perf_PerfInstrument__559 *)&t1->payload.perf;
-   t11 = instruments_perf_PerfInstrument_add_marker__758(t10, a1, t4);
+   t11 = instruments_perf_PerfInstrument_add_marker__759(t10, a1, t4);
    memcpy(&t12, &t11, sizeof(uint16_t));
    t6 = t12;
    goto zig_block_3;
@@ -8151,21 +8302,21 @@ uint8_t c_instrument_hooks_add_marker__250(struct instruments_root_InstrumentHoo
  return UINT8_C(0);
 }
 
-uint64_t c_instrument_hooks_current_timestamp__251(void) {
+uint64_t c_instrument_hooks_current_timestamp__252(void) {
  uint64_t t0;
- t0 = utils_clock_gettime_monotonic__4220();
+ t0 = utils_clock_gettime_monotonic__3834();
  return t0;
 }
 
-static uint64_t utils_clock_gettime_monotonic__4220(void) {
- struct os_linux_timespec__struct_2843__2843 t0;
- struct os_linux_timespec__struct_2843__2843 t3;
- nav__4220_41 t1;
+static uint64_t utils_clock_gettime_monotonic__3834(void) {
+ struct os_linux_timespec__struct_2922__2922 t0;
+ struct os_linux_timespec__struct_2922__2922 t3;
+ nav__3834_41 t1;
  intptr_t t4;
  uint64_t t5;
  uint64_t t6;
  bool t2;
- t1 = posix_clock_gettime__1630(UINT32_C(1));
+ t1 = posix_clock_gettime__1633(UINT32_C(1));
  t2 = t1.error == UINT16_C(0);
  if (t2) {
   t3 = t1.payload;
@@ -8184,31 +8335,31 @@ static uint64_t utils_clock_gettime_monotonic__4220(void) {
  return t6;
 }
 
-static uint64_t const builtin_zig_backend__256 = UINT64_C(3);
+static uint64_t const builtin_zig_backend__257 = UINT64_C(3);
 
 static bool const start_simplified_logic__109 = false;
 
-static uint8_t const builtin_output_mode__257 = UINT8_C(1);
+static uint8_t const builtin_output_mode__258 = UINT8_C(1);
 
-static uint8_t const builtin_link_mode__258 = UINT8_C(0);
+static uint8_t const builtin_link_mode__259 = UINT8_C(0);
 
-static uint64_t features_features__323 = ((uint64_t)UINT64_C(0));
+static uint64_t features_features__324 = ((uint64_t)UINT64_C(0));
 
-static uintptr_t const bit_set_IntegerBitSet_2864_29_bit_length__354 = 64ul;
+static uintptr_t const bit_set_IntegerBitSet_2864_29_bit_length__355 = 64ul;
 
-static bool const builtin_link_libc__268 = true;
+static bool const builtin_link_libc__269 = true;
 
-static bool const posix_use_libc__1282 = true;
+static bool const posix_use_libc__1285 = true;
 
-static struct Target_Os__625 const builtin_os__264 = {{ .linux = {{{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}}},{2ul,39ul,0ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},UINT32_C(14)} },UINT8_C(9)};
+static struct Target_Os__625 const builtin_os__265 = {{ .linux = {{{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}}},{2ul,39ul,0ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},UINT32_C(14)} },UINT8_C(9)};
 
-static uint8_t const c_native_os__1724 = UINT8_C(9);
+static uint8_t const c_native_os__1727 = UINT8_C(9);
 
-static struct Target_DynamicLinker__800 const Target_DynamicLinker_none__3446 = {"\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252",UINT8_C(0)};
+static struct Target_DynamicLinker__800 const Target_DynamicLinker_none__3449 = {"\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252",UINT8_C(0)};
 
-static bool const builtin_is_test__260 = false;
+static bool const builtin_is_test__261 = false;
 
-static uint8_t *heap_CAllocator_alloc__3570(void *const a0, uintptr_t const a1, uint8_t const a2, uintptr_t const a3) {
+static uint8_t *heap_CAllocator_alloc__3573(void *const a0, uintptr_t const a1, uint8_t const a2, uintptr_t const a3) {
  uint64_t t0;
  uint8_t *t2;
  bool t1;
@@ -8217,11 +8368,11 @@ static uint8_t *heap_CAllocator_alloc__3570(void *const a0, uintptr_t const a1, 
  t0 = a1;
  t1 = t0 > UINT64_C(0);
  debug_assert__180(t1);
- t2 = heap_CAllocator_alignedAlloc__3567(a1, a2);
+ t2 = heap_CAllocator_alignedAlloc__3570(a1, a2);
  return t2;
 }
 
-static bool heap_CAllocator_resize__3571(void *const a0, nav__3571_40 const a1, uint8_t const a2, uintptr_t const a3, uintptr_t const a4) {
+static bool heap_CAllocator_resize__3574(void *const a0, nav__3574_40 const a1, uint8_t const a2, uintptr_t const a3, uintptr_t const a4) {
  uintptr_t t0;
  uint64_t t1;
  uint64_t t2;
@@ -8241,7 +8392,7 @@ static bool heap_CAllocator_resize__3571(void *const a0, nav__3571_40 const a1, 
 
  zig_block_0:;
  t4 = a1.ptr;
- t0 = heap_CAllocator_alignedAllocSize__3569(t4);
+ t0 = heap_CAllocator_alignedAllocSize__3572(t4);
  t2 = a3;
  t1 = t0;
  t3 = t2 <= t1;
@@ -8254,12 +8405,12 @@ static bool heap_CAllocator_resize__3571(void *const a0, nav__3571_40 const a1, 
  return false;
 }
 
-static uint8_t *heap_CAllocator_remap__3572(void *const a0, nav__3572_40 const a1, uint8_t const a2, uintptr_t const a3, uintptr_t const a4) {
+static uint8_t *heap_CAllocator_remap__3575(void *const a0, nav__3575_40 const a1, uint8_t const a2, uintptr_t const a3, uintptr_t const a4) {
  uint8_t *t0;
  uint8_t *t2;
  uint8_t *t3;
  bool t1;
- t1 = heap_CAllocator_resize__3571(a0, a1, a2, a3, a4);
+ t1 = heap_CAllocator_resize__3574(a0, a1, a2, a3, a4);
  if (t1) {
   t2 = a1.ptr;
   t3 = (uint8_t *)t2;
@@ -8273,17 +8424,17 @@ static uint8_t *heap_CAllocator_remap__3572(void *const a0, nav__3572_40 const a
  return t0;
 }
 
-static void heap_CAllocator_free__3573(void *const a0, nav__3573_40 const a1, uint8_t const a2, uintptr_t const a3) {
+static void heap_CAllocator_free__3576(void *const a0, nav__3576_40 const a1, uint8_t const a2, uintptr_t const a3) {
  uint8_t *t0;
  (void)a0;
  (void)a2;
  (void)a3;
  t0 = a1.ptr;
- heap_CAllocator_alignedFree__3568(t0);
+ heap_CAllocator_alignedFree__3571(t0);
  return;
 }
 
-static uint8_t *heap_CAllocator_alignedAlloc__3567(uintptr_t const a0, uint8_t const a1) {
+static uint8_t *heap_CAllocator_alignedAlloc__3570(uintptr_t const a0, uint8_t const a1) {
  uint8_t const *t1;
  uintptr_t t3;
  uint64_t t4;
@@ -8298,7 +8449,7 @@ static uint8_t *heap_CAllocator_alignedAlloc__3567(uintptr_t const a0, uint8_t c
  t0 = a1;
  t1 = (uint8_t const *)&t0;
  t2 = (*t1);
- t3 = mem_Alignment_toByteUnits__1044(t2);
+ t3 = mem_Alignment_toByteUnits__1045(t2);
  t3 = ((uintptr_t)8ul > t3) ? (uintptr_t)8ul : t3;
  t4 = t3;
  t3 = t4;
@@ -8316,7 +8467,7 @@ static uint8_t *heap_CAllocator_alignedAlloc__3567(uintptr_t const a0, uint8_t c
  return t10;
 }
 
-static uintptr_t heap_CAllocator_alignedAllocSize__3569(uint8_t *const a0) {
+static uintptr_t heap_CAllocator_alignedAllocSize__3572(uint8_t *const a0) {
  void const *t0;
  void const *t1;
  uintptr_t t2;
@@ -8326,7 +8477,7 @@ static uintptr_t heap_CAllocator_alignedAllocSize__3569(uint8_t *const a0) {
  return t2;
 }
 
-static void heap_CAllocator_alignedFree__3568(uint8_t *const a0) {
+static void heap_CAllocator_alignedFree__3571(uint8_t *const a0) {
  void *t0;
  void *t1;
  t0 = (void *)a0;
@@ -8335,7 +8486,7 @@ static void heap_CAllocator_alignedFree__3568(uint8_t *const a0) {
  return;
 }
 
-static uintptr_t mem_Alignment_toByteUnits__1044(uint8_t const a0) {
+static uintptr_t mem_Alignment_toByteUnits__1045(uint8_t const a0) {
  uintptr_t t1;
  uint8_t t0;
  t0 = a0;
@@ -8343,93 +8494,99 @@ static uintptr_t mem_Alignment_toByteUnits__1044(uint8_t const a0) {
  return t1;
 }
 
-static struct mem_Allocator__565 const heap_c_allocator__3535 = {((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3562)};
+static struct mem_Allocator__565 const heap_c_allocator__3538 = {((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3565)};
 
-static struct mem_Allocator__565 const c_allocator__235 = {((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3562)};
+static struct mem_Allocator__565 const c_allocator__236 = {((void *)(uintptr_t)0xaaaaaaaaaaaaaaaaul),((struct mem_Allocator_VTable__568 const *)&heap_CAllocator_vtable__3565)};
 
-static struct Target_Cpu_Feature_Set__817 const Target_Cpu_Feature_Set_empty__3491 = {{0ul,0ul,0ul,0ul,0ul}};
+static struct Target_Cpu_Feature_Set__817 const Target_Cpu_Feature_Set_empty__3494 = {{0ul,0ul,0ul,0ul,0ul}};
 
-static struct Target_Cpu__785 const builtin_cpu__263 = {((struct Target_Cpu_Model__812 const *)&Target_x86_cpu_alderlake__3594),{{9528139926881771760ul,4854352088661217417ul,15258802296178673304ul,3ul,0ul}},UINT8_C(42)};
+static struct Target_Cpu__785 const builtin_cpu__264 = {((struct Target_Cpu_Model__812 const *)&Target_x86_cpu_alderlake__3597),{{9528139926881771760ul,4854352088661217417ul,15258802296178673304ul,3ul,0ul}},UINT8_C(42)};
 
-static uint8_t const builtin_abi__262 = UINT8_C(1);
+static uint8_t const builtin_abi__263 = UINT8_C(1);
 
-static uint8_t const builtin_object_format__266 = UINT8_C(0);
+static uint8_t const builtin_object_format__267 = UINT8_C(0);
 
-static struct Target__623 const builtin_target__265 = {{((struct Target_Cpu_Model__812 const *)&Target_x86_cpu_alderlake__3594),{{9528139926881771760ul,4854352088661217417ul,15258802296178673304ul,3ul,0ul}},UINT8_C(42)},{{ .linux = {{{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}}},{2ul,39ul,0ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},UINT32_C(14)} },UINT8_C(9)},UINT8_C(1),UINT8_C(0),{"/nix/store/g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66/lib/ld-linux-x86-64.so.2\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252",UINT8_C(82)}};
+static struct Target__623 const builtin_target__266 = {{((struct Target_Cpu_Model__812 const *)&Target_x86_cpu_alderlake__3597),{{9528139926881771760ul,4854352088661217417ul,15258802296178673304ul,3ul,0ul}},UINT8_C(42)},{{ .linux = {{{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},{6ul,16ul,7ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}}},{2ul,39ul,0ul,{NULL,0xaaaaaaaaaaaaaaaaul},{NULL,0xaaaaaaaaaaaaaaaaul}},UINT32_C(14)} },UINT8_C(9)},UINT8_C(1),UINT8_C(0),{"/nix/store/zdpby3l6azi78sl83cpad2qjpfj25aqx-glibc-2.40-66/lib/ld-linux-x86-64.so.2\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252\252",UINT8_C(82)}};
 
-static struct builtin_CallingConvention__266 const builtin_CallingConvention_c__464 = {{ .x86_64_sysv = {{UINT64_C(0xaaaaaaaaaaaaaaaa),true}} },UINT8_C(4)};
+static struct builtin_CallingConvention__266 const builtin_CallingConvention_c__465 = {{ .x86_64_sysv = {{UINT64_C(0xaaaaaaaaaaaaaaaa),true}} },UINT8_C(4)};
 
-static uint8_t const (*const shared_RUNNER_CTL_FIFO__3698)[21] = &__anon_1845;
+static uint8_t const (*const shared_RUNNER_CTL_FIFO__3701)[21] = &__anon_1845;
 
-static uint8_t const (*const shared_RUNNER_ACK_FIFO__3699)[21] = &__anon_1905;
+static uint8_t const (*const shared_RUNNER_ACK_FIFO__3702)[21] = &__anon_1916;
 
-static uint64_t const c_PROTOCOL_VERSION__236 = UINT64_C(1);
+static uint64_t const c_PROTOCOL_VERSION__237 = UINT64_C(1);
 
-static uint8_t const mem_native_endian__768 = UINT8_C(1);
+static uint8_t const mem_native_endian__769 = UINT8_C(1);
 
-static uint8_t const os_linux_native_arch__2630 = UINT8_C(42);
+static int const cimport_F_GETFL__5129 = 3;
 
-static int const cimport_EINTR__5831 = 4;
+static int const cimport_O_NONBLOCK__5105 = 2048;
 
-static uint8_t const fs_path_native_os__4236 = UINT8_C(9);
+static int const cimport_F_SETFL__5130 = 4;
 
-static uint8_t const fs_native_os__1094 = UINT8_C(9);
+static uint8_t const os_linux_native_arch__2633 = UINT8_C(42);
 
-static uint8_t const fs_Dir_native_os__3822 = UINT8_C(9);
+static int const cimport_EINTR__6758 = 4;
 
-static bool const fs_File_is_windows__1270 = false;
+static uint8_t const fs_path_native_os__4243 = UINT8_C(9);
 
-static uint8_t const posix_native_os__1280 = UINT8_C(9);
+static uint8_t const fs_native_os__1097 = UINT8_C(9);
 
-static uint8_t const builtin_mode__267 = UINT8_C(3);
+static uint8_t const fs_Dir_native_os__3825 = UINT8_C(9);
+
+static bool const fs_File_is_windows__1273 = false;
+
+static uint8_t const posix_native_os__1283 = UINT8_C(9);
+
+static uint8_t const builtin_mode__268 = UINT8_C(3);
 
 static bool const debug_runtime_safety__159 = false;
 
-static bool const fs_Dir_have_flock__3823 = true;
+static bool const fs_Dir_have_flock__3826 = true;
 
-static uint8_t const c_native_abi__1722 = UINT8_C(1);
+static uint8_t const c_native_abi__1725 = UINT8_C(1);
 
-static bool const posix_unexpected_error_tracing__1711 = false;
+static bool const posix_unexpected_error_tracing__1714 = false;
 
-static bool const posix_lfs64_abi__1710 = true;
+static bool const posix_lfs64_abi__1713 = true;
 
-static bool const mem_backend_supports_vectors__796 = true;
+static bool const mem_backend_supports_vectors__797 = true;
 
-static bool const builtin_valgrind_support__271 = false;
+static bool const builtin_valgrind_support__272 = false;
 
 static bool const debug_default_enable_segfault_handler__205 = false;
 
-static uint8_t const log_default_level__6375 = UINT8_C(0);
+static uint8_t const log_default_level__7302 = UINT8_C(0);
 
-static struct std_Options__4209 const std_options__97 = {{0xaaaaaaaaaaaaaaaaul,true},{0xaaaaaaaaaaaaaaaaul,true},3ul,false,UINT8_C(0),false,true,false,false,false,UINT8_C(2)};
+static struct std_Options__4269 const std_options__97 = {{0xaaaaaaaaaaaaaaaaul,true},{0xaaaaaaaaaaaaaaaaul,true},3ul,false,UINT8_C(0),false,true,false,false,false,UINT8_C(2)};
 
-static nav__3551_38 const heap_page_size_min_default__3551 = {4096ul,false};
+static nav__3554_38 const heap_page_size_min_default__3554 = {4096ul,false};
 
-static uintptr_t const heap_page_size_min__3530 = 4096ul;
+static uintptr_t const heap_page_size_min__3533 = 4096ul;
 
-static uint16_t const fmt_max_format_args__6443 = UINT16_C(32);
+static uint16_t const fmt_max_format_args__7370 = UINT16_C(32);
 
-static uint8_t const (*const fmt_ANY__6446)[4] = &__anon_4953;
+static uint8_t const (*const fmt_ANY__7373)[4] = &__anon_5013;
 
-static uint8_t const unicode_native_endian__6668 = UINT8_C(1);
+static uint8_t const unicode_native_endian__7595 = UINT8_C(1);
 
-static uint32_t const unicode_replacement_character__6669 = UINT32_C(65533);
+static uint32_t const unicode_replacement_character__7596 = UINT32_C(65533);
 
-static uint8_t const c_MARKER_TYPE_SAMPLE_START__246 = UINT8_C(0);
+static uint8_t const c_MARKER_TYPE_SAMPLE_START__247 = UINT8_C(0);
 
-static uint8_t const c_MARKER_TYPE_SAMPLE_END__247 = UINT8_C(1);
+static uint8_t const c_MARKER_TYPE_SAMPLE_END__248 = UINT8_C(1);
 
-static uint8_t const c_MARKER_TYPE_BENCHMARK_START__248 = UINT8_C(2);
+static uint8_t const c_MARKER_TYPE_BENCHMARK_START__249 = UINT8_C(2);
 
-static uint8_t const c_MARKER_TYPE_BENCHMARK_END__249 = UINT8_C(3);
+static uint8_t const c_MARKER_TYPE_BENCHMARK_END__250 = UINT8_C(3);
 
-static struct mem_Allocator_VTable__568 const heap_CAllocator_vtable__3562 = {&heap_CAllocator_alloc__3570,&heap_CAllocator_resize__3571,&heap_CAllocator_remap__3572,&heap_CAllocator_free__3573};
+static struct mem_Allocator_VTable__568 const heap_CAllocator_vtable__3565 = {&heap_CAllocator_alloc__3573,&heap_CAllocator_resize__3574,&heap_CAllocator_remap__3575,&heap_CAllocator_free__3576};
 
-static bool const heap_CAllocator_supports_malloc_size__3563 = true;
+static bool const heap_CAllocator_supports_malloc_size__3566 = true;
 
-static bool const heap_CAllocator_supports_posix_memalign__3565 = true;
+static bool const heap_CAllocator_supports_posix_memalign__3568 = true;
 
-static struct Target_Cpu_Model__812 const Target_x86_cpu_alderlake__3594 = {{(uint8_t const *)&__anon_5232,9ul},{(uint8_t const *)&__anon_5232,9ul},{{9516916112185360560ul,4872366487170699401ul,11223533324467504792ul,3ul,0ul}}};
+static struct Target_Cpu_Model__812 const Target_x86_cpu_alderlake__3597 = {{(uint8_t const *)&__anon_5291,9ul},{(uint8_t const *)&__anon_5291,9ul},{{9516916112185360560ul,4872366487170699401ul,11223533324467504792ul,3ul,0ul}}};
 
 #endif
 #ifndef WRAPPER_H

--- a/src/c.zig
+++ b/src/c.zig
@@ -6,6 +6,10 @@ const shared = @import("./shared.zig");
 const std = @import("std");
 const utils = @import("./utils.zig");
 
+// Note: Using printf to avoid the extra code from std.log/std.debug. Those won't
+// compile because they are internally using syscalls (for Mutexes) which aren't cross-platform.
+extern "c" fn printf(format: [*c]const c_char, ...) c_int;
+
 pub const panic = if (builtin.is_test) std.debug.FullPanic(std.debug.defaultPanic) else std.debug.no_panic;
 const allocator = if (builtin.is_test) std.testing.allocator else std.heap.c_allocator;
 
@@ -27,7 +31,14 @@ pub export fn instrument_hooks_init() ?*InstrumentHooks {
     };
 
     if (hooks.* == .perf) {
-        hooks.perf.send_version(PROTOCOL_VERSION) catch {};
+        hooks.perf.send_version(PROTOCOL_VERSION) catch {
+            _ = printf(@as([*c]const c_char, @ptrCast("[ERROR] instrument-hooks: failed to communicate with CodSpeed runner\n")));
+            _ = printf(@as([*c]const c_char, @ptrCast("[ERROR] instrument-hooks: please update the CodSpeed action to the latest version\n")));
+
+            hooks.deinit();
+            allocator.destroy(hooks);
+            std.posix.exit(1);
+        };
     }
 
     return hooks;

--- a/src/fifo.zig
+++ b/src/fifo.zig
@@ -35,18 +35,30 @@ pub const UnixPipe = struct {
         pub fn recvCmd(self: *Reader) !Command {
             // First read the length (u32 = 4 bytes)
             var len_buffer: [4]u8 = undefined;
-            _ = try self.file.readAll(&len_buffer);
+            const len_read = self.file.readAll(&len_buffer) catch |err| {
+                // Convert blocking/broken pipe errors to something the timeout logic can handle
+                return switch (err) {
+                    error.WouldBlock, error.BrokenPipe => error.NotReady,
+                    else => err,
+                };
+            };
+            if (len_read < 4) {
+                return error.UnexpectedEof;
+            }
             const message_len = std.mem.readInt(u32, &len_buffer, std.builtin.Endian.little);
 
             // Read the message
             const buffer = try self.allocator.alloc(u8, message_len);
             defer self.allocator.free(buffer);
 
-            while (true) {
-                _ = self.file.readAll(buffer) catch {
-                    continue;
+            const msg_read = self.file.readAll(buffer) catch |err| {
+                return switch (err) {
+                    error.WouldBlock, error.BrokenPipe => error.NotReady,
+                    else => err,
                 };
-                break;
+            };
+            if (msg_read < message_len) {
+                return error.UnexpectedEof;
             }
 
             var stream = std.io.fixedBufferStream(buffer);
@@ -63,10 +75,16 @@ pub const UnixPipe = struct {
                     return error.AckTimeout;
                 }
 
-                const cmd = self.recvCmd() catch {
-                    const utils = @import("utils.zig");
-                    utils.sleep(std.time.ns_per_ms * 10);
-                    continue;
+                const cmd = self.recvCmd() catch |err| {
+                    // Only retry on transient errors, propagate fatal ones
+                    switch (err) {
+                        error.NotReady, error.UnexpectedEof => {
+                            const utils = @import("utils.zig");
+                            utils.sleep(std.time.ns_per_ms * 10);
+                            continue;
+                        },
+                        else => return err,
+                    }
                 };
 
                 return cmd;
@@ -136,20 +154,26 @@ pub const UnixPipe = struct {
         }
     }
 
-    pub fn openRead(allocator: Allocator, path: []const u8) !Reader {
+    fn openPipe(path: []const u8) !fs.File {
         try fs.accessAbsolute(path, .{ .mode = .read_write });
+        const file = try fs.openFileAbsolute(path, .{
+            .mode = .read_write,
+        });
 
-        const file = try fs.openFileAbsolute(path, .{ .mode = .read_write, .lock = .shared, .lock_nonblocking = true });
+        // Zig doesn't set the nonblocking flag correctly, so we have to do it manually.
+        const utils = @import("utils.zig");
+        utils.setNonBlocking(file.handle);
+
+        return file;
+    }
+
+    pub fn openRead(allocator: Allocator, path: []const u8) !Reader {
+        const file = try openPipe(path);
         return Reader.init(file, allocator);
     }
 
     pub fn openWrite(allocator: Allocator, path: []const u8) !Writer {
-        try fs.accessAbsolute(path, .{ .mode = .read_write });
-
-        // DO NOT REMOVE the .lock, as nonblocking will have no effect otherwise. This can lead to
-        // deadlocks invalid/broken FIFOs are opened.
-        // See: https://github.com/ziglang/zig/blob/ffd85ffcda3c36b2cda0783ab285ede8b0fc55af/lib/std/fs/Dir.zig#L872-L887
-        const file = try fs.openFileAbsolute(path, .{ .mode = .read_write, .lock = .shared, .lock_nonblocking = true });
+        const file = try openPipe(path);
         return Writer.init(file, allocator);
     }
 };
@@ -231,4 +255,22 @@ test "unix pipe send recv cmd" {
     defer cmd.deinit(writer.allocator);
 
     try std.testing.expectEqual(Command.StartBenchmark, cmd);
+}
+
+test "unix pipe send without ack" {
+    const allocator = std.testing.allocator;
+    const test_path = "/tmp/test_no_ack.fifo";
+
+    try UnixPipe.create(test_path);
+
+    // Open both reader and writer so they don't block on open
+    var reader = try UnixPipe.openRead(allocator, test_path);
+    defer reader.deinit();
+
+    var writer = try UnixPipe.openWrite(allocator, test_path);
+    defer writer.deinit();
+
+    // Writer doesn't send anything, so waitForResponse should timeout
+    const result = reader.waitForResponse(std.time.ns_per_ms * 100);
+    try std.testing.expectError(error.AckTimeout, result);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const c = @cImport(@cInclude("time.h"));
 const errno = @cImport(@cInclude("errno.h"));
+const fcntl_h = @cImport(@cInclude("fcntl.h"));
 
 extern "c" fn nanosleep(nanos: u64) c_int;
 
@@ -27,6 +28,12 @@ pub fn sleep(nanoseconds: u64) void {
             return;
         }
     }
+}
+
+pub fn setNonBlocking(fd: std.posix.fd_t) void {
+    const current_flags = fcntl_h.fcntl(fd, fcntl_h.F_GETFL, @as(c_int, 0));
+    const new_flags = current_flags | fcntl_h.O_NONBLOCK;
+    _ = fcntl_h.fcntl(fd, fcntl_h.F_SETFL, new_flags);
 }
 
 // Returns monotonic time since boot in nanoseconds.


### PR DESCRIPTION
Works now: 
```
►►► Running the benchmarks 
Events disabled
Running as unit: run-p2661361-i2661362.scope; invocation ID: 26bc315124524057a45efc154a19a11b
instrument-hooks: failed to communicate with CodSpeed runner: AckTimeout
instrument-hooks: please update the CodSpeed action to the latest version
[ perf record: Woken up 12 times to write data ]
[ perf record: Dump /tmp/nix-shell.SjIUuH/.tmpyxL6PI/perf.data.uT4rjw.2025100311462558 ]
[ perf record: Captured and wrote 0.088 MB /tmp/nix-shell.SjIUuH/.tmpyxL6PI/perf.data.uT4rjw.<timestamp> ]
Error: failed to execute the benchmark process: exit status: 1
```