### PR TITLE
chore(tests): align rust deser harness with renamed runner-shared variants

### DIFF
--- a/src/tests/deserialize_rust/Cargo.lock
+++ b/src/tests/deserialize_rust/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "runner-shared"
 version = "0.1.0"
-source = "git+https://github.com/CodSpeedHQ/runner#be3c3b2502c9aa1155264d5447af3a80c5b90d98"
+source = "git+https://github.com/CodSpeedHQ/runner?rev=214016018bb8ff32014af4ab77e8bc5260fcc878#214016018bb8ff32014af4ab77e8bc5260fcc878"
 dependencies = [
  "anyhow",
  "bincode",

--- a/src/tests/deserialize_rust/Cargo.toml
+++ b/src/tests/deserialize_rust/Cargo.toml
@@ -11,4 +11,4 @@ path = "main.rs"
 [dependencies]
 bincode = "1.3.3"
 serde = { version = "1.0.192", features = ["derive"] }
-runner-shared = { git = "https://github.com/CodSpeedHQ/runner" }
+runner-shared = { git = "https://github.com/CodSpeedHQ/runner", rev = "214016018bb8ff32014af4ab77e8bc5260fcc878" }

--- a/src/tests/deserialize_rust/main.rs
+++ b/src/tests/deserialize_rust/main.rs
@@ -34,10 +34,10 @@ fn main() {
             uri: "http://example.com/benchmark".to_string(),
         },
     );
-    example("cmd_start_bench", &Command::StartBenchmark);
-    example("cmd_stop_bench", &Command::StopBenchmark);
+    example("cmd_start_bench", &Command::StartProfiler);
+    example("cmd_stop_bench", &Command::StopProfiler);
     example("cmd_ack", &Command::Ack);
-    example("cmd_ping_perf", &Command::PingPerf);
+    example("cmd_ping_perf", &Command::PingProfiler);
     example(
         "cmd_set_integration",
         &Command::SetIntegration {
@@ -64,21 +64,21 @@ fn main() {
         "cmd_add_marker_benchmark_start",
         &Command::AddMarker {
             pid: 12345,
-            marker: MarkerType::BenchmarkStart(3000),
+            marker: MarkerType::RoundStart(3000),
         },
     );
     example(
         "cmd_add_marker_benchmark_end",
         &Command::AddMarker {
             pid: 12345,
-            marker: MarkerType::BenchmarkEnd(4000),
+            marker: MarkerType::RoundEnd(4000),
         },
     );
     example("cmd_set_version", &Command::SetVersion(1));
     example("cmd_get_runner_mode", &Command::GetIntegrationMode);
     example(
         "cmd_runner_mode_perf",
-        &Command::IntegrationModeResponse(IntegrationMode::Perf),
+        &Command::IntegrationModeResponse(IntegrationMode::Walltime),
     );
     example(
         "cmd_runner_mode_simulation",


### PR DESCRIPTION
## Summary
- `StartBenchmark`/`StopBenchmark`/`PingPerf` and `MarkerType::Benchmark{Start,End}` were renamed in `runner-shared`, and `IntegrationMode::Perf` became `Walltime`.
- Updates the serialization harness to use the new names. Wire ordinals are unchanged, so the Zig side and `serialized.zig` stay byte-identical.

## Test plan
- [x] `cargo check` in `src/tests/deserialize_rust`
- [x] `zig build test` (via pre-commit hooks)