### PR TITLE
feat: add callgrind_toggle_collect helper

### DIFF
--- a/dist/core.c
+++ b/dist/core.c
@@ -61296,6 +61296,8 @@ void callgrind_start_instrumentation() {}
 
 void callgrind_stop_instrumentation() {}
 
+void callgrind_toggle_collect() {}
+
 void callgrind_add_obj_skip(uint8_t const *path) { (void)path; }
 #else
 #include "callgrind.h"
@@ -61314,6 +61316,8 @@ void callgrind_zero_stats() { CALLGRIND_ZERO_STATS; }
 void callgrind_start_instrumentation() { CALLGRIND_START_INSTRUMENTATION; }
 
 void callgrind_stop_instrumentation() { CALLGRIND_STOP_INSTRUMENTATION; }
+
+void callgrind_toggle_collect() { CALLGRIND_TOGGLE_COLLECT; }
 
 void callgrind_add_obj_skip(uint8_t const *path) {
   CALLGRIND_ADD_OBJ_SKIP(path);

--- a/includes/core.h
+++ b/includes/core.h
@@ -49,6 +49,13 @@ uint64_t instrument_hooks_current_timestamp(void);
 void callgrind_start_instrumentation();
 void callgrind_stop_instrumentation();
 
+// Toggle callgrind cost collection on/off without re-instrumenting.
+// Unlike start/stop instrumentation, this does not flush the simulated
+// cache, so it can be used to exclude code regions from measurement
+// without introducing artificial cold-cache costs.
+// Safe to call outside Valgrind: expands to a no-op.
+void callgrind_toggle_collect();
+
 // Register an object file path on callgrind's runtime --obj-skip list.
 // Equivalent to passing --obj-skip=<path> on the valgrind command line.
 // Safe to call outside Valgrind: expands to a no-op.

--- a/src/helpers/valgrind_wrapper.c
+++ b/src/helpers/valgrind_wrapper.c
@@ -17,6 +17,8 @@ void callgrind_start_instrumentation() {}
 
 void callgrind_stop_instrumentation() {}
 
+void callgrind_toggle_collect() {}
+
 void callgrind_add_obj_skip(uint8_t const *path) { (void)path; }
 #else
 #include "callgrind.h"
@@ -35,6 +37,8 @@ void callgrind_zero_stats() { CALLGRIND_ZERO_STATS; }
 void callgrind_start_instrumentation() { CALLGRIND_START_INSTRUMENTATION; }
 
 void callgrind_stop_instrumentation() { CALLGRIND_STOP_INSTRUMENTATION; }
+
+void callgrind_toggle_collect() { CALLGRIND_TOGGLE_COLLECT; }
 
 void callgrind_add_obj_skip(uint8_t const *path) {
   CALLGRIND_ADD_OBJ_SKIP(path);


### PR DESCRIPTION
Expose CALLGRIND_TOGGLE_COLLECT as a wrapper next to the existing
start/stop instrumentation helpers. Unlike toggling instrumentation,
toggling collection does not flush the simulated cache, so integrations
can exclude code regions (e.g. google benchmark's PauseTiming sections)
from measurement without paying an artificial cold-cache warmup in the
measured region.

Refs COD-2033.
